### PR TITLE
Instantiate gpu properties map

### DIFF
--- a/gpu/gpu_info.go
+++ b/gpu/gpu_info.go
@@ -48,7 +48,7 @@ func pciGpus(pciDevices []pci.Device) ([]Gpu, error) {
 
 func vendorSpecificProperties(pciDevice pci.Device) map[string]interface{} {
 
-	var properties map[string]interface{}
+	properties := make(map[string]interface{})
 
 	switch pciDevice.VendorId {
 	case 0x1002: // AMD


### PR DESCRIPTION
Fixes:
```
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/canonical/hardware-info/gpu.vendorSpecificProperties({{0xc000188860, 0xc}, 0x300, 0xc000014158, 0x1002, 0x1638, 0xc000014154, 0xc000014156, {0x0, 0x0, ...}})
        /root/parts/hardware-info/build/gpu/gpu_info.go:59 +0x4db
github.com/canonical/hardware-info/gpu.pciGpus({0xc00019c008?, 0x1676?, 0x2000?})
        /root/parts/hardware-info/build/gpu/gpu_info.go:41 +0x378
github.com/canonical/hardware-info/gpu.Info(0x0?)
        /root/parts/hardware-info/build/gpu/gpu_info.go:15 +0x2a
main.main()
        /root/parts/hardware-info/build/cmd/hardware-info/main.go:46 +0x3e5
```