### PR TITLE
Add nvidia-smi to path in install hook

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+mkdir $SNAP_DATA/bin
+cp /var/lib/snapd/hostfs/usr/bin/nvidia-smi $SNAP_DATA/bin || true
+chmod -R +x $SNAP_DATA/bin

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ base: core24
 version: git
 summary: Utilities for snapping ML workloads
 description: |
-  These utilities helps decide which components should be installed on a particular system.
+  These utilities help decide which components should be installed on a particular system.
 
 grade: devel
 confinement: strict
@@ -13,12 +13,15 @@ layout:
   /usr/share/misc/pci.ids:
     bind-file: $SNAP/pci.ids
 
+hooks:
+  install:
+    plugs: [system-backup]
+
 parts:
   system-utilities:
     plugin: nil
     stage-packages:
       - pciutils
-      - nvidia-utils
 
   # To use `version: git` in this file, we require git as a build dependency.
   # This is fixed but not published yet. See https://github.com/canonical/snapcraft/issues/4944
@@ -41,6 +44,9 @@ parts:
 
 apps:
   hardware-info:
+    environment:
+      # Install hook puts a copy of nvidia-smi here
+      PATH: $SNAP_DATA/bin:$PATH
     plugs:
       - hardware-observe
       - opengl


### PR DESCRIPTION
`system-backup` interface is not auto-connected when the install hook runs on a classic system. Need to install in dev mode.

This approach also does not work:
* `nvidia-smi` from the host is dynamically linked to a different version of glibc than is available in the snap