### PR TITLE
hwinfo: exit with error on no permissions

### DIFF
--- a/cmd/hardware-info/main.go
+++ b/cmd/hardware-info/main.go
@@ -28,25 +28,25 @@ func main() {
 
 	memoryInfo, err := memory.Info()
 	if err != nil {
-		log.Println("Failed to get memory info:", err)
+		log.Fatalf("Failed to get memory info: %s", err)
 	}
 	hwInfo.Memory = memoryInfo
 
 	cpuInfo, err := cpu.Info()
 	if err != nil {
-		log.Println("Failed to get CPU info:", err)
+		log.Fatalf("Failed to get CPU info: %s", err)
 	}
 	hwInfo.Cpu = cpuInfo
 
 	diskInfo, err := disk.Info()
 	if err != nil {
-		log.Println("Failed to get disk info:", err)
+		log.Fatalf("Failed to get disk info: %s", err)
 	}
 	hwInfo.Disk = diskInfo
 
 	gpuInfo, err := gpu.Info(friendlyNames)
 	if err != nil {
-		log.Println("Failed to get GPU info:", err)
+		log.Fatalf("Failed to get GPU info: %s", err)
 	}
 	hwInfo.Gpus = gpuInfo
 


### PR DESCRIPTION
If the snap does not have the hardware-observe interface connected, the hardware info app can not read the CPU info. Rather than omitting this info, and letting the selector choose an inferior or non stack, rather exit with a failure.

This PR changes the app to exit with and error code if cpu, memory, disk or gpu info can't be obtained.