### PR TITLE
Improve component installation logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/canonical/stack-utils
 go 1.24
 
 require (
+	github.com/briandowns/spinner v1.23.2
 	github.com/canonical/go-snapctl v1.0.0-beta.2
 	github.com/fatih/color v1.18.0
 	github.com/jaypipes/pcidb v1.0.1
@@ -14,4 +15,5 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	golang.org/x/term v0.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/briandowns/spinner v1.23.2 h1:Zc6ecUnI+YzLmJniCfDNaMbW0Wid1d5+qcTq4L2FW8w=
+github.com/briandowns/spinner v1.23.2/go.mod h1:LaZeM4wm2Ywy6vO571mvhQNRcWfRUnXOs0RcKV0wYKM=
 github.com/canonical/go-snapctl v1.0.0-beta.2 h1:3M+9+uAg8vu5hIGQN/yOOcG6Esud7/eQgtZbD7DNjco=
 github.com/canonical/go-snapctl v1.0.0-beta.2/go.mod h1:c2Kkyh24L/nYD7YSLzoA6n/mI3/86IQekwXvBHL3G+Q=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -21,6 +23,8 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/term v0.1.0 h1:g6Z6vPFA9dYBAF7DWcH6sCcOntplXsDKcliusYijMlw=
+golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
- List what is being downloaded
- Show progress info
- Add special handle for timeout error
- Do not exit on local install errors to get the full list of components that should be installed

Example outputs:

Timeout:
```console
$ sudo deepseek-r1.init 
Downloaded llamacpp
Error: timeout exceeded while waiting for download of model-distill-qwen-7b-q4-k-m-gguf
Please monitor the progress using the 'snap changes' command and continue when the component installation is complete.
```

Local build:
```console
$ sudo deepseek-r1.init 
Error: snap not known to the store. Install a local build of component: llamacpp-cuda
Error: snap not known to the store. Install a local build of component: model-distill-qwen-7b-q4-k-m-gguf
/snap/deepseek-r1/x1/bin/init.sh: line 33: /snap/deepseek-r1/components/x1/model-distill-qwen-7b-q4-k-m-gguf/init: No such file or directory
```

Progress info:

[Screencast From 2025-06-26 23-40-06.webm](https://github.com/user-attachments/assets/1982b8b3-9c86-4456-85d5-1ecd6d1bedd3)


