### PR TITLE
Return nvidia-smi error messages

### DIFF
--- a/pkg/hardware_info/pci/nvidia/gpu.go
+++ b/pkg/hardware_info/pci/nvidia/gpu.go
@@ -1,6 +1,7 @@
 package nvidia
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -41,46 +42,56 @@ func vRam(device types.PciDevice) (*uint64, error) {
 		$ nvidia-smi --id=00000000:02:00.0 --query-gpu=memory.total --format=csv,noheader
 		No devices were found
 	*/
-	command := exec.Command("nvidia-smi", "--id="+device.Slot, "--query-gpu=memory.total", "--format=csv,noheader")
-	command.Env = os.Environ()
-	command.Env = append(command.Env, "LANG=C")
-	data, err := command.Output()
+	output, err := nvidiaSmi("--id="+device.Slot, "--query-gpu=memory.total", "--format=csv,noheader")
+	if err != nil {
+		return nil, fmt.Errorf("error executing nvidia-smi: %s", err)
+	}
+
+	valueStr, unit, hasUnit := strings.Cut(*output, " ")
+	vramValue, err := strconv.ParseUint(valueStr, 10, 64)
 	if err != nil {
 		return nil, err
-	} else {
-		dataStr := string(data)
-		dataStr = strings.TrimSpace(dataStr) // value ends in \n
-		valueStr, unit, hasUnit := strings.Cut(dataStr, " ")
-		vramValue, err := strconv.ParseUint(valueStr, 10, 64)
-		if err != nil {
-			return nil, err
-		}
-
-		if hasUnit {
-			switch unit {
-			case "KiB":
-				vramValue = vramValue * 1024
-			case "MiB":
-				vramValue = vramValue * 1024 * 1024
-			case "GiB":
-				vramValue = vramValue * 1024 * 1024 * 1024
-			}
-		}
-
-		return &vramValue, nil
 	}
+
+	if hasUnit {
+		switch unit {
+		case "KiB":
+			vramValue = vramValue * 1024
+		case "MiB":
+			vramValue = vramValue * 1024 * 1024
+		case "GiB":
+			vramValue = vramValue * 1024 * 1024 * 1024
+		}
+	}
+
+	return &vramValue, nil
+
 }
 
 func computeCapability(device types.PciDevice) (*string, error) {
-	// nvidia-smi --query-gpu=compute_cap --format=csv
-	command := exec.Command("nvidia-smi", "--id="+device.Slot, "--query-gpu=compute_cap", "--format=csv,noheader")
-	command.Env = os.Environ()
-	command.Env = append(command.Env, "LANG=C")
-	data, err := command.Output()
+	// nvidia-smi --query-gpu=compute_cap --format=csv,noheader
+	output, err := nvidiaSmi("--id="+device.Slot, "--query-gpu=compute_cap", "--format=csv,noheader")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error executing nvidia-smi: %s", err)
 	}
 
-	ccValue := strings.TrimSpace(string(data))
-	return &ccValue, nil
+	return output, nil
+}
+
+func nvidiaSmi(args ...string) (*string, error) {
+	cmd := exec.Command("nvidia-smi", args...)
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, "LANG=C")
+	output, err := cmd.Output()
+	if err != nil {
+		if len(output) == 0 {
+			return nil, err
+		} else {
+			// nvidia-smi writes error messages to stdout
+			return nil, fmt.Errorf("%s: %s", err, bytes.TrimSpace(output))
+		}
+	}
+
+	strOutput := string(bytes.TrimSpace(output))
+	return &strOutput, nil
 }


### PR DESCRIPTION
See issue https://github.com/canonical/inference-snaps/issues/128

With this fix:
```
NVIDIA: error looking up compute capability: error executing nvidia-smi: exit status 2: Field "compute_cap" is not a valid field to query.
```