### PR TITLE
Add reusable Github action to publish snap

### DIFF
--- a/.github/actions/snap-publish/README.md
+++ b/.github/actions/snap-publish/README.md
@@ -1,0 +1,55 @@
+# Publish snaps
+
+This is a Github Action that can be used to publish snap packages to the Snap Store.
+
+Unlike [`canonical/action-publish`](https://github.com/canonical/action-publish), this action also uploads the component snaps defined in `snap/snapcraft.yaml`.
+
+## Basic Usage
+
+If you wish to define your job inline, you can use the following step:
+
+```yaml
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build snap
+        uses: canonical/action-build@v1
+
+      - name: Publish snap
+        uses: canonical/stack-utils/.github/actions/snap-publish
+        with:
+          store-credentials: ${{ secrets.STORE_LOGIN }}
+```
+
+## Store login
+
+This action requires a Snap Store login secret saved in Github as secret. Export a token as `secret.json` and add its content as a repository secret named `STORE_LOGIN`:
+
+```bash
+snapcraft export-login \
+    --snaps "<snap-name>" \
+    --channels "latest/edge/*" \
+    --acls package_access,package_push,package_update,package_release \
+    --expires 2026-08-15T00:00:00Z \
+    secret.json
+```
+
+## API
+
+### Inputs
+
+| Name | Description | Default | Required |
+|---|---|---|---|
+| `store-credentials` | Snap Store credentials to publish the snap. | `""` | true |
+
+## How it works
+
+**Publish step**  
+Uses a bundled `upload.sh` script to parse `snap/snapcraft.yaml` and validate snap and components to upload them all to the Snap Store using `snapcraft upload --release=<channel>`
+
+  - On branch/tag builds: channel is defined to `latest/edge/<short-sha>`  
+  - On pull request builds: channel is defined to `latest/edge/pr-<number>`

--- a/.github/actions/snap-publish/action.yml
+++ b/.github/actions/snap-publish/action.yml
@@ -1,0 +1,43 @@
+name: Publish snap
+description: >
+  Publish a snap and its components to a channel in the Snap Store.
+  When triggered from a PR, the channel is set to `latest/edge/pr-<pr-num>`,
+  otherwise, it is set to `latest/edge/<short-git-hash>`.
+
+inputs:
+  store-credentials:
+    description: >
+      The Snapcraft store credentials to use
+
+      This parameter is required to publish a snap and
+      its components to Snap Store.
+    default: ''
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # Requires store crendentials secret set.
+    # Check README.md for steps on how to generate it and use it in workflows.
+    - name: Publish snap
+      shell: bash
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ inputs.store-credentials }}
+      run: |
+        if [ -z "$SNAPCRAFT_STORE_CREDENTIALS" ]; then
+          echo "SNAPCRAFT_STORE_CREDENTIALS is not set."
+          exit 1
+        fi
+
+        channel="latest/edge/$(git rev-parse --short HEAD)"
+        echo "Branch name: ${{ github.ref_name }}"
+        echo "Event number: ${{ github.event.number }}"
+
+        if [ -n "${{ github.event.number }}" ]; then
+          echo "Triggered from a PR"
+          channel="latest/edge/pr-${{ github.event.number }}"
+        fi
+
+        echo "Uploading to channel: $channel"
+
+        "${{ github.action_path }}/upload.sh" "$channel"

--- a/.github/actions/snap-publish/upload.sh
+++ b/.github/actions/snap-publish/upload.sh
@@ -1,0 +1,54 @@
+#!/bin/bash -eu
+
+function check_file() {
+    local file=$1
+    if [ ! -f "$file" ]; then
+        echo "Error: file not found: $file"
+        exit 1
+    fi
+}
+
+channel=$1
+arch=${2:-$(dpkg --print-architecture)} # if not set, take the current architecture
+
+if [[ "$(yq --version)" != *v4* ]]; then
+    echo "Please install yq v4."
+    exit 1
+fi
+
+# validate channel
+if [[ ! "$channel" =~ ^[a-z0-9-]+/[a-z0-9-]+(/[a-z0-9-]+)?$ ]]; then
+    echo "Invalid Snap channel: $channel"
+    exit 1
+fi
+
+# load snapcraft.yaml into variable, explode to evaluate aliases
+snapcraft_yaml=$(yq '. | explode(.)' snap/snapcraft.yaml)
+
+snap_name=$(echo "$snapcraft_yaml" | yq '.name')
+snap_version=$(echo "$snapcraft_yaml" | yq '.version')
+snap_file="${snap_name}_${snap_version}_${arch}.snap"
+check_file "$snap_file"
+snap_size=$(du -h "$snap_file" | cut -f1)
+
+echo -e "Snap file:\n\t$snap_file $snap_size"
+
+# Extract components from snapcraft.yaml
+components=$(echo "$snapcraft_yaml" | yq '.components | to_entries | .[].key')
+
+# Build components argument list
+component_args=()
+echo "Snap components:"
+for comp_name in $components; do
+    comp_ver=$(echo "$snapcraft_yaml" | yq ".components.$comp_name.version")
+    comp_file="${snap_name}+${comp_name}_${comp_ver}.comp"
+    check_file "$comp_file"
+    comp_size=$(du -h "$comp_file" | cut -f1)
+    echo -e "\t$comp_file $comp_size"
+
+    component_args+=(--component "$comp_name=$comp_file")
+done
+
+echo -e "Channel:\n\t$channel"
+
+snapcraft upload "$snap_file" "${component_args[@]}" --release="$channel"


### PR DESCRIPTION
- Tested by copying the github action in a local Github repo (my github repo could not access [canonical/stack-utils](https://github.com/canonical/stack-utils) actions)
- Successful workflow is here: https://github.com/sidalit/test-snap/actions/runs/17120019237/job/48558571877