### PR TITLE
Set specific order for commands

### DIFF
--- a/cmd/stack/chat.go
+++ b/cmd/stack/chat.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
+func addChatCommand() {
 	cmd := &cobra.Command{
 		Use:               "chat",
 		Short:             "Start the chat CLI",

--- a/cmd/stack/debug.go
+++ b/cmd/stack/debug.go
@@ -14,7 +14,7 @@ var (
 	debugMachineInfoFormat string
 )
 
-func init() {
+func addDebugCommand() {
 	debugCmd := &cobra.Command{
 		Use:   "debug",
 		Short: "Debugging commands",

--- a/cmd/stack/get.go
+++ b/cmd/stack/get.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
+func addGetCommand() {
 	cmd := &cobra.Command{
 		Use:   "get <key>",
 		Short: "Print configuration option",

--- a/cmd/stack/info.go
+++ b/cmd/stack/info.go
@@ -11,9 +11,9 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func init() {
+func addInfoCommand() {
 	cmd := &cobra.Command{
-		Use:   "variant <variant>",
+		Use:   "show-variant <variant>",
 		Short: "Print information about a variant",
 		// Long:  "",
 		GroupID:           "variants",

--- a/cmd/stack/list.go
+++ b/cmd/stack/list.go
@@ -18,7 +18,7 @@ var (
 	listAll bool
 )
 
-func init() {
+func addListCommand() {
 	cmd := &cobra.Command{
 		Use:   "list-variants",
 		Short: "List available variants",

--- a/cmd/stack/main.go
+++ b/cmd/stack/main.go
@@ -18,6 +18,23 @@ var (
 )
 
 func main() {
+	cobra.EnableCommandSorting = false
+
+	rootCmd.AddGroup(&cobra.Group{ID: "basics", Title: "Basic Commands:"})
+	addStatusCommand()
+	addChatCommand()
+
+	rootCmd.AddGroup(&cobra.Group{ID: "config", Title: "Configuration Commands:"})
+	addGetCommand()
+	addSetCommand()
+	addUnsetCommand()
+
+	rootCmd.AddGroup(&cobra.Group{ID: "variants", Title: "Management Commands:"})
+	addListCommand()
+	addInfoCommand()
+	addUseCommand()
+	addPruneCommand()
+
 	// disable logging timestamps
 	log.SetFlags(0)
 
@@ -26,12 +43,6 @@ func main() {
 		rootCmd.Use = "app"
 	}
 
-	// Define groups for subcommands - used in usage help text
-	rootCmd.AddGroup(
-		&cobra.Group{ID: "basics", Title: "Basic Commands:"},
-		&cobra.Group{ID: "variants", Title: "Management Commands:"},
-		&cobra.Group{ID: "config", Title: "Configuration Commands:"},
-	)
 	// Hide the 'completion' command from help text
 	rootCmd.CompletionOptions.HiddenDefaultCmd = true
 

--- a/cmd/stack/prune.go
+++ b/cmd/stack/prune.go
@@ -11,7 +11,7 @@ var (
 	pruneAll bool
 )
 
-func init() {
+func addPruneCommand() {
 	cmd := &cobra.Command{
 		Use:   "prune-variant [<variant>]",
 		Short: "Remove unused variant resources",

--- a/cmd/stack/set.go
+++ b/cmd/stack/set.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
+func addSetCommand() {
 	cmd := &cobra.Command{
 		Use:   "set <key>",
 		Short: "Set configuration option",

--- a/cmd/stack/status.go
+++ b/cmd/stack/status.go
@@ -17,7 +17,7 @@ var (
 	statusFormat string
 )
 
-func init() {
+func addStatusCommand() {
 	cmd := &cobra.Command{
 		Use:               "status",
 		Short:             "Show the status",

--- a/cmd/stack/unset.go
+++ b/cmd/stack/unset.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
+func addUnsetCommand() {
 	cmd := &cobra.Command{
 		Use:   "unset <key>",
 		Short: "Unset configuration option",

--- a/cmd/stack/use.go
+++ b/cmd/stack/use.go
@@ -23,7 +23,7 @@ var (
 	useAssumeYes bool
 )
 
-func init() {
+func addUseCommand() {
 	cmd := &cobra.Command{
 		Use:   "use-variant [<variant>]",
 		Short: "Select a variant",


### PR DESCRIPTION
* Change variant to show-variant
* Force specific order for commands - this is quick fix. I'll do a refactoring separately.

Help:
```
Usage:
  qwen-vl [command]

Basic Commands:
  status        Show the status
  chat          Start the chat CLI

Configuration Commands:
  get           Print configuration option
  set           Set configuration option
  unset         Unset configuration option

Management Commands:
  list-variants List available variants
  show-variant  Print information about a variant
  use-variant   Select a variant
  prune-variant Remove unused variant resources

Additional Commands:
  help          Help about any command

Flags:
  -h, --help   help for qwen-vl

Use "qwen-vl [command] --help" for more information about a command.
```

