### PR TITLE
Always list all engines

### DIFF
--- a/cmd/cli/list.go
+++ b/cmd/cli/list.go
@@ -93,7 +93,6 @@ func printEnginesTable(scoredEngines []engines.ScoredManifest) error {
 	engineVendorMaxLen += 2
 	// Description column fills the remaining space
 	engineDescriptionMaxLen := tableMaxWidth - (engineNameMaxLen + engineVendorMaxLen)
-
 	// Reserve space for Compatible column
 	engineDescriptionMaxLen -= len(headerRow[3]) + 2
 


### PR DESCRIPTION
<img width="1732" height="1258" alt="image" src="https://github.com/user-attachments/assets/cd61faa3-96bb-4204-a413-5636d82f9fd0" />

```
$ stack-utils list-engines --all
Error: unknown flag: --all
$ stack-utils list-engines
 ENGINE          VENDOR             DESCRIPTION                          COMPAT 
 intel-cpu       Intel Corporation  Use Intel CPUs                       yes    
 example-memory  Canonical Ltd      Legacy CPUs, offering full accura…   yes    
 cpu-avx2        Canonical Ltd      CPUs with AVX2                       yes    
 cpu-avx1        Canonical Ltd      Legacy CPUs with only SSE4.2 (200…   yes    
 cpu-devel       Canonical Ltd      Requires any CPU but is grade devel  beta   
 ampere-altra    Canonical Ltd      Test ampere selection                no     
 intel-gpu       Intel Corporation  Modern Intel GPUs (>=gen 13)         no     
 cuda-generic    Canonical Ltd      Nvidia GPUs using CUDA. All major…   no     
 arm-neon        Canonical Ltd      ARM CPUs with NEON instruction set   no     
 ampere          Canonical Ltd      Test ampere selection                no     
 intel-npu       Intel Corporation  Intel NPUs                           no     
 cpu-avx512      Canonical Ltd      CPUs with AVX512                     no     
```