### PR TITLE
Fix: get returns unexpected configs

### DIFF
--- a/pkg/storage/config.go
+++ b/pkg/storage/config.go
@@ -53,7 +53,9 @@ func (c *config) Get(key string) (map[string]any, error) {
 
 	// Filter to needed keys
 	for k := range configs {
-		if !strings.HasPrefix(k, key) {
+		// Only keep exact key matches for both primitives and objects
+		// e.g. model and model.source
+		if k != key && !strings.HasPrefix(k, key+".") {
 			delete(configs, k)
 		}
 	}


### PR DESCRIPTION
The `hasPrefix` caught more keys than intended, making `get()` return unexpected values. For example `get("model")` returned both `model` and `model-name`, while the latter was not expected. We do however need to return objects with a prefix like `model.*`.

Resolves:
* https://github.com/canonical/inference-snaps/issues/95
* https://github.com/canonical/inference-snaps/issues/94