### PR TITLE
Clear user overrides of engine config, after switching engines

### DIFF
--- a/pkg/storage/cache.go
+++ b/pkg/storage/cache.go
@@ -27,8 +27,6 @@ const (
 	activeEngineKey = cacheKeyPrefix + "active-engine"
 )
 
-var ErrNoCache = errors.New("no cache")
-
 func (c cache) SetActiveEngine(engine string) error {
 	if engine == "" {
 		return fmt.Errorf("engine name cannot be empty")
@@ -37,11 +35,12 @@ func (c cache) SetActiveEngine(engine string) error {
 	return c.storage.Set(activeEngineKey, engine)
 }
 
+// GetActiveEngine returns the currently active engine name, or an empty string if none is set
 func (c *cache) GetActiveEngine() (string, error) {
 	data, err := c.storage.Get(activeEngineKey)
 	if err != nil {
-		if errors.Is(err, ErrorNotFound) { // cache miss
-			return "", ErrNoCache
+		if errors.Is(err, ErrorNotFound) { // cache miss, no active engine set
+			return "", nil
 		}
 		return "", err
 	}


### PR DESCRIPTION
Fixes canonical/inference-snaps#167 

```console
$ sudo qwen-vl set gpu-layers=10

$ qwen-vl get
gpu-layers: 10
http.base-path: v1
http.host: 127.0.0.1
http.port: 8080
model: model-qwen2-5-vl-7b-instruct-q4-k-m
multimodel-projector: mmproj-qwen2-5-vl-7b-instruct-q8-0
server: llamacpp-cuda
verbose: false

$ sudo qwen-vl use-engine cpu-tiny
Restarting the snap service ...
Engine successfully changed to "cpu-tiny"

$ qwen-vl get
http.base-path: v1
http.host: 127.0.0.1
http.port: 8080
model: model-qwen2-5-vl-3b-instruct-q4-k-m
multimodel-projector: mmproj-qwen2-5-vl-3b-instruct-q8-0
server: llamacpp
verbose: false
```
