### PR TITLE
Disallow setting unknown keys

### DIFF
--- a/pkg/storage/config.go
+++ b/pkg/storage/config.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"fmt"
 	"maps"
 	"strings"
 )
@@ -35,6 +36,17 @@ const (
 
 // Set sets a configuration value
 func (c *config) Set(key, value string, confType configType) error {
+	// User configs are overrides, reject unknown keys
+	if confType == UserConfig {
+		valMap, err := c.Get(key)
+		if err != nil {
+			return fmt.Errorf("error checking existing keys: %s", err)
+		}
+		if len(valMap) == 0 {
+			return fmt.Errorf("unknown key")
+		}
+	}
+
 	return c.storage.Set(c.nestKeys(confType, key), value)
 }
 


### PR DESCRIPTION
Fixes canonical/inference-snaps#165 

```console
$ qwen-vl status 
Using cpu-tiny

OpenAI API at http://localhost:8080/v1

Run "sudo snap stop qwen-vl" to stop the server.

$ qwen-vl get
http.base-path: v1
http.host: 127.0.0.1
http.port: 8080
model: model-qwen2-5-vl-3b-instruct-q4-k-m
multimodel-projector: mmproj-qwen2-5-vl-3b-instruct-q8-0
server: llamacpp
verbose: false

$ sudo qwen-vl set gpu-layers=10
Error: error setting value "10" for "gpu-layers": unknown key

$ sudo qwen-vl use-engine cuda
Restarting the snap service ...
Engine successfully changed to "cuda"

$ sudo qwen-vl set gpu-layers=10

$ qwen-vl get
gpu-layers: 10
http.base-path: v1
http.host: 127.0.0.1
http.port: 8080
model: model-qwen2-5-vl-7b-instruct-q4-k-m
multimodel-projector: mmproj-qwen2-5-vl-7b-instruct-q8-0
server: llamacpp-cuda
verbose: false
```