### PR TITLE
Add a spinner while looking up model status

### DIFF
--- a/cmd/cli/status.go
+++ b/cmd/cli/status.go
@@ -38,6 +38,8 @@ func status(_ *cobra.Command, _ []string) error {
 	var err error
 
 	stopProgress := startProgressSpinner("Getting status ")
+	defer stopProgress()
+
 	switch statusFormat {
 	case "json":
 		statusText, err = statusJson()
@@ -55,6 +57,7 @@ func status(_ *cobra.Command, _ []string) error {
 			return fmt.Errorf("error getting status: %v", err)
 		}
 	}
+
 	stopProgress()
 
 	fmt.Println(statusText)


### PR DESCRIPTION
Related:
* Resolves canonical/inference-snaps#169 

This is a workaround for the slow status. Rather than waiting without feedback to the user (~15 seconds sometimes), show a spinner.

The slow part is the first prompt to the model, which requires the model to be loaded into memory. We can address this in the check-server script at a later stage.

Check around 24s into this video:

https://github.com/user-attachments/assets/8e764390-5637-4a19-88d1-0f50254ad7ec

