### PR TITLE
Fix `show-engine` bugs

### DIFF
--- a/cmd/cli/show.go
+++ b/cmd/cli/show.go
@@ -31,6 +31,9 @@ func showEngine(_ *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("could not get currently selected engine: %v", err)
 		}
+		if currentEngine == "" {
+			return fmt.Errorf(`No active engine. Select one with "use-engine".`)
+		}
 		return engineInfo(currentEngine)
 
 	} else if len(args) == 1 {
@@ -67,6 +70,9 @@ func engineInfo(engineName string) error {
 		if scoredEngines[i].Name == engineName {
 			scoredManifest = scoredEngines[i]
 		}
+	}
+	if scoredManifest.Name != engineName {
+		return fmt.Errorf(`engine "%s" does not exist`, engineName)
 	}
 
 	err = printEngineInfo(scoredManifest)


### PR DESCRIPTION
Related:
* Resolves canonical/inference-snaps#162 
* Resolves canonical/inference-snaps#161 

No engine active:
```
$ sudo snap get stack-utils cache -d
{
        "cache": {}
}
```

Output of show engine for currently active engine:
```
$ stack-utils show-engine
Error: No active engine. Select one with "use-engine".
```

Output of show-engine when an invalid engine name is specified:
```
$ stack-utils show-engine invalid-name
Error: engine "invalid-name" does not exist
```