### PR TITLE
Show config deprecation notice to users only

### DIFF
--- a/cmd/cli/get.go
+++ b/cmd/cli/get.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"slices"
 
+	"github.com/canonical/famous-models-cli/pkg/utils"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -62,7 +63,7 @@ func getValue(key string) error {
 	}
 
 	// Warn the user about deprecated fields. These are still consumed by the engines.
-	if slices.Contains(deprecatedConfig, key) {
+	if slices.Contains(deprecatedConfig, key) && utils.IsTerminalOutput() {
 		fmt.Fprintf(os.Stderr, "Note: %q configuration field is deprecated!\n", key)
 	}
 


### PR DESCRIPTION
Fixes canonical/inference-snaps#159 


```console
$ qwen-vl chat
Type your prompt, then ENTER to submit. CTRL-C to quit.
» ^C
$ qwen-vl get model-name
Qwen2.5-VL-3B-Instruct-ov-int4
Note: "model-name" configuration field is deprecated!
```