### PR TITLE
Add engine to status text

### DIFF
--- a/cmd/cli/status.go
+++ b/cmd/cli/status.go
@@ -127,7 +127,7 @@ func statusHuman() (string, error) {
 
 func statusHumanEngine(engine *engines.ScoredManifest, auto bool) string {
 	bold := color.New(color.Bold).SprintFunc()
-	engineString := fmt.Sprintf("Using %s", bold(engine.Name))
+	engineString := fmt.Sprintf("Using %s engine", bold(engine.Name))
 	if auto {
 		engineString += " (automatically selected)"
 	}


### PR DESCRIPTION
```console
$ qwen-vl status
Using cpu-tiny engine

OpenAI API at http://localhost:8080/v1

Run "sudo snap stop qwen-vl" to stop the server.
```