### PR TITLE
Uniform line break and syntax highlighting

### DIFF
--- a/cmd/cli/show-machine.go
+++ b/cmd/cli/show-machine.go
@@ -28,25 +28,22 @@ func showMachine(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get hardware info: %s", err)
 	}
 
-	var hwInfoStr string
 	switch debugMachineInfoFormat {
 	case "json":
 		jsonString, err := json.MarshalIndent(hwInfo, "", "  ")
 		if err != nil {
 			return fmt.Errorf("failed to marshal to JSON: %s", err)
 		}
-		hwInfoStr = string(jsonString)
+		fmt.Printf("%s\n", jsonString)
 	case "yaml":
 		yamlString, err := yaml.Marshal(hwInfo)
 		if err != nil {
 			return fmt.Errorf("failed to marshal to YAML: %s", err)
 		}
-		hwInfoStr = string(yamlString)
+		fmt.Printf("%s", yamlString)
 	default:
 		return fmt.Errorf("unknown format %q", debugMachineInfoFormat)
 	}
-
-	fmt.Println(hwInfoStr)
 
 	return nil
 }

--- a/cmd/cli/show.go
+++ b/cmd/cli/show.go
@@ -2,12 +2,9 @@ package main
 
 import (
 	"fmt"
-	"os"
 
-	"github.com/alecthomas/chroma/v2/quick"
 	"github.com/canonical/inference-snaps-cli/pkg/engines"
 	"github.com/canonical/inference-snaps-cli/pkg/selector"
-	"github.com/canonical/inference-snaps-cli/pkg/utils"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -88,15 +85,7 @@ func printEngineInfo(engine engines.ScoredManifest) error {
 		return fmt.Errorf("error converting engine to yaml: %v", err)
 	}
 
-	if utils.IsTerminalOutput() {
-		err = quick.Highlight(os.Stdout, string(engineYaml), "yaml", "terminal", "colorful")
-		if err != nil {
-			return fmt.Errorf("error formatting yaml: %v", err)
-		}
-	} else {
-		fmt.Print(string(engineYaml))
-		return nil
-	}
+	fmt.Print(string(engineYaml))
 
 	return nil
 }

--- a/cmd/cli/status.go
+++ b/cmd/cli/status.go
@@ -46,6 +46,7 @@ func status(_ *cobra.Command, _ []string) error {
 		if err != nil {
 			return fmt.Errorf("error getting json status: %v", err)
 		}
+		statusText += "\n"
 	case "yaml":
 		statusText, err = statusYaml()
 		if err != nil {
@@ -56,11 +57,12 @@ func status(_ *cobra.Command, _ []string) error {
 		if err != nil {
 			return fmt.Errorf("error getting status: %v", err)
 		}
+		statusText += "\n"
 	}
 
 	stopProgress()
 
-	fmt.Println(statusText)
+	fmt.Print(statusText)
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.24.0
 toolchain go1.24.6
 
 require (
-	github.com/alecthomas/chroma/v2 v2.20.0
 	github.com/briandowns/spinner v1.23.2
 	github.com/canonical/go-snapctl v1.0.0-beta.3
 	github.com/fatih/color v1.18.0
@@ -19,7 +18,6 @@ require (
 )
 
 require (
-	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,3 @@
-github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
-github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/chroma/v2 v2.20.0 h1:sfIHpxPyR07/Oylvmcai3X/exDlE8+FA820NTz+9sGw=
-github.com/alecthomas/chroma/v2 v2.20.0/go.mod h1:e7tViK0xh/Nf4BYHl00ycY6rV7b8iXBksI9E359yNmA=
-github.com/alecthomas/repr v0.5.1 h1:E3G4t2QbHTSNpPKBgMTln5KLkZHLOcU7r37J4pXBuIg=
-github.com/alecthomas/repr v0.5.1/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/briandowns/spinner v1.23.2 h1:Zc6ecUnI+YzLmJniCfDNaMbW0Wid1d5+qcTq4L2FW8w=
 github.com/briandowns/spinner v1.23.2/go.mod h1:LaZeM4wm2Ywy6vO571mvhQNRcWfRUnXOs0RcKV0wYKM=
 github.com/canonical/go-snapctl v1.0.0-beta.3 h1:lVfhh+7aRndPABZIVfDV19tdsxaSNKFWi3tkQ71XjEY=
@@ -11,14 +5,10 @@ github.com/canonical/go-snapctl v1.0.0-beta.3/go.mod h1:c2Kkyh24L/nYD7YSLzoA6n/m
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
-github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
-github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
-github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jaypipes/pcidb v1.1.1 h1:QmPhpsbmmnCwZmHeYAATxEaoRuiMAJusKYkUncMC0ro=


### PR DESCRIPTION
Remove syntax highlighting and print yaml without an extra line break.

There are a few inconsistencies in the output when serialization is yaml:
- `status --format=yaml` is yaml with an extra line break
- `show-engine` is yaml, syntax highlighted, no extra line break (as expected). The syntax highlighting isn't great: 
  Ubuntu dark:
  <img width="1558" height="530" alt="image" src="https://github.com/user-attachments/assets/0fb7ca30-82db-4904-a114-fe4e64053f4b" />
  Tango dark:
  <img width="1558" height="530" alt="image" src="https://github.com/user-attachments/assets/23f02b15-e9af-4445-958c-186a38c763bd" />
  GNOME dark:
  <img width="1558" height="530" alt="image" src="https://github.com/user-attachments/assets/4e36e369-5b53-4808-bf30-bcfd7adcb1d6" />
- `show-machine` is yaml with an extra line break

Testing after the changes:
```console
$ qwen-vl status
Using cpu-tiny engine

OpenAI API at http://localhost:8326/v1

Run "sudo snap stop qwen-vl" to stop the server.
$ qwen-vl status --format=yaml 
engine: cpu-tiny
status: online
endpoints:
    openai: http://localhost:8326/v1
$ qwen-vl status --format=json
{
  "engine": "cpu-tiny",
  "status": "online",
  "endpoints": {
    "openai": "http://localhost:8326/v1"
  }
}
$ 
$ qwen-vl show-engine
...
compatible: true
$
$ qwen-vl show-machine
...
pci:
    - slot: "0000:00:00.0"
...
      subvendor-name: CLEVO/KAPOK Computer
$ qwen-vl show-machine --format=json
{
...
}
```

