### PR TITLE
Default status format to yaml

### DIFF
--- a/cmd/cli/status.go
+++ b/cmd/cli/status.go
@@ -28,7 +28,7 @@ func addStatusCommand() {
 	}
 
 	// flags
-	cmd.PersistentFlags().StringVar(&statusFormat, "format", "", "return the status as yaml or json")
+	cmd.PersistentFlags().StringVar(&statusFormat, "format", "yaml", "output format")
 
 	rootCmd.AddCommand(cmd)
 }
@@ -52,12 +52,14 @@ func status(_ *cobra.Command, _ []string) error {
 		if err != nil {
 			return fmt.Errorf("error getting yaml status: %v", err)
 		}
-	default:
+	case "plain":
 		statusText, err = statusHuman()
 		if err != nil {
 			return fmt.Errorf("error getting status: %v", err)
 		}
 		statusText += "\n"
+	default:
+		return fmt.Errorf("unknown format %q", statusFormat)
 	}
 
 	stopProgress()


### PR DESCRIPTION
```console
$ qwen-vl status -h
Show the status of the model snap

Usage:
  qwen-vl status [flags]

Flags:
      --format string   output format (default "yaml")
  -h, --help            help for status
$ qwen-vl status 
engine: cpu-tiny
status: online
endpoints:
    openai: http://localhost:8326/v1
$ qwen-vl status --format=json
{
  "engine": "cpu-tiny",
  "status": "online",
  "endpoints": {
    "openai": "http://localhost:8326/v1"
  }
}
$ qwen-vl status --format=plain # deprecated but kept for now
Using cpu-tiny engine

OpenAI API at http://localhost:8326/v1

Run "sudo snap stop qwen-vl" to stop the server.
```