### PR TITLE
Label devel engines as devel in list-engines

### DIFF
--- a/cmd/cli/list.go
+++ b/cmd/cli/list.go
@@ -66,7 +66,7 @@ func printEnginesTable(scoredEngines []engines.ScoredManifest) error {
 		if engine.Compatible && engine.Grade == "stable" {
 			compatibleStr = "yes"
 		} else if engine.Compatible {
-			compatibleStr = "beta"
+			compatibleStr = "devel"
 		} else {
 			compatibleStr = "no"
 		}


### PR DESCRIPTION
Closes canonical/inference-snaps#156 

```console
$ stack-utils list-engines
ENGINE           VENDOR             DESCRIPTION                          COMPAT
cuda-generic     Canonical Ltd      Nvidia GPUs using CUDA. All major …  yes   
intel-gpu        Intel Corporation  Modern Intel GPUs (>=gen 13)         yes   
intel-cpu        Intel Corporation  Use Intel CPUs                       yes   
example-memory   Canonical Ltd      Legacy CPUs, offering full accurac…  yes   
cpu-avx2         Canonical Ltd      CPUs with AVX2                       yes   
cpu-avx1         Canonical Ltd      Legacy CPUs with only SSE4.2 (2008…  yes   
cpu-devel        Canonical Ltd      Requires any CPU but is grade devel  devel 
intel-npu        Intel Corporation  Intel NPUs                           no    
cpu-avx512       Canonical Ltd      CPUs with AVX512                     no    
arm-neon         Canonical Ltd      ARM CPUs with NEON instruction set   no    
ampere-altra     Canonical Ltd      Test ampere selection                no    
ampere           Canonical Ltd      Test ampere selection                no    
$
$ stack-utils show-engine cpu-devel
name: cpu-devel
description: Requires any CPU but is grade devel
vendor: Canonical Ltd
grade: devel
devices:
    anyof:
        - type: cpu
          architecture: amd64
        - type: cpu
          architecture: arm64
memory: 1G
disk-space: 2G
components: []
configurations: {}
score: 12
compatible: true
$
$ sudo stack-utils use-engine --auto
Evaluating engines for optimal hardware compatibility:
✘ ampere: not compatible: required cpu device not found
✘ ampere-altra: not compatible: required cpu device not found
✘ arm-neon: not compatible: required device not found
✔ cpu-avx1: compatible, score=14
✔ cpu-avx2: compatible, score=17
✘ cpu-avx512: not compatible: required cpu device not found
− cpu-devel: devel, score=12
✔ cuda-generic: compatible, score=107
✔ example-memory: compatible, score=18
✔ intel-cpu: compatible, score=18
✔ intel-gpu: compatible, score=72
✘ intel-npu: not compatible: required device not found
Selected engine: cuda-generic
```