### PR TITLE
Do not cache device names

### DIFF
--- a/pkg/storage/cache.go
+++ b/pkg/storage/cache.go
@@ -84,7 +84,7 @@ func (c *cache) GetMachineInfo() (*types.HwInfo, error) {
 }
 
 func (c *cache) loadMachineInfo() (*types.HwInfo, error) {
-	machine, err := hardware_info.Get(true)
+	machine, err := hardware_info.Get(false)
 	if err != nil {
 		return nil, fmt.Errorf("error getting machine info: %v", err)
 	}


### PR DESCRIPTION
Closes canonical/inference-snaps#151 