### PR TITLE
Get hardware info requires root

### DIFF
--- a/pkg/hardware_info/hardware-info.go
+++ b/pkg/hardware_info/hardware-info.go
@@ -11,9 +11,16 @@ import (
 	"github.com/canonical/inference-snaps-cli/pkg/hardware_info/memory"
 	"github.com/canonical/inference-snaps-cli/pkg/hardware_info/pci"
 	"github.com/canonical/inference-snaps-cli/pkg/types"
+	"github.com/canonical/inference-snaps-cli/pkg/utils"
 )
 
 func Get(friendlyNames bool) (*types.HwInfo, error) {
+	// Loading machine info requires root on at least Ubuntu 25.10
+	// This is so that clinfo has permission to look up vram
+	if !utils.IsRootUser() {
+		return nil, fmt.Errorf("permission denied, try again with sudo")
+	}
+
 	var hwInfo types.HwInfo
 
 	memoryInfo, err := memory.Info()


### PR DESCRIPTION
Related:
* Resolves canonical/inference-snaps#152 

Tested on Ubuntu 25.04. User not added to `render` group:
```
$ stack-utils show-machine
Error: failed to get machine info: permission denied, try again with sudo
$
$ sudo stack-utils show-machine
[sudo] password for jpmeijers: 
cpus:
    - architecture: amd64
      manufacturer-id: GenuineIntel
      flags:
        - ...
memory:
    total-ram: 15908737024
    total-swap: 34359734272
disk:
    /:
        total: 7954366464
        avail: 7954366464
    /var/lib/snapd/snaps:
        total: 1003736440832
        avail: 635570356224
pci:
    - slot: "0000:00:02.0"
      bus-number: "0x0"
      device-class: "0x300"
      programming-interface: 0
      vendor-id: "0x8086"
      device-id: "0x9B41"
      subvendor-id: "0x1028"
      subdevice-id: "0x962"
      vendor-name: Intel Corporation
      device-name: CometLake-U GT2 [UHD Graphics]
      subvendor-name: Dell
      additional-properties:
        vram: "14482350080"
...
```

```
$ stack-utils list-engines
Error: error scoring engines: error getting machine info: error getting machine info: permission denied, try again with sudo
$
$ sudo stack-utils list-engines
ENGINE           VENDOR             DESCRIPTION                          COMPAT
intel-cpu        Intel Corporation  Use Intel CPUs                       yes   
example-memory   Canonical Ltd      Legacy CPUs, offering full accurac…  yes   
cpu-avx2         Canonical Ltd      CPUs with AVX2                       yes   
cpu-avx1         Canonical Ltd      Legacy CPUs with only SSE4.2 (2008…  yes   
cpu-devel        Canonical Ltd      Requires any CPU but is grade devel  devel 
intel-npu        Intel Corporation  Intel NPUs                           no    
intel-gpu        Intel Corporation  Modern Intel GPUs (>=gen 13)         no    
cuda-generic     Canonical Ltd      Nvidia GPUs using CUDA. All major …  no    
cpu-avx512       Canonical Ltd      CPUs with AVX512                     no    
arm-neon         Canonical Ltd      ARM CPUs with NEON instruction set   no    
ampere-altra     Canonical Ltd      Test ampere selection                no    
ampere           Canonical Ltd      Test ampere selection                no 
$
$ stack-utils list-engines
ENGINE           VENDOR             DESCRIPTION                          COMPAT
intel-cpu        Intel Corporation  Use Intel CPUs                       yes   
example-memory   Canonical Ltd      Legacy CPUs, offering full accurac…  yes   
cpu-avx2         Canonical Ltd      CPUs with AVX2                       yes   
cpu-avx1         Canonical Ltd      Legacy CPUs with only SSE4.2 (2008…  yes   
cpu-devel        Canonical Ltd      Requires any CPU but is grade devel  devel 
intel-npu        Intel Corporation  Intel NPUs                           no    
intel-gpu        Intel Corporation  Modern Intel GPUs (>=gen 13)         no    
cuda-generic     Canonical Ltd      Nvidia GPUs using CUDA. All major …  no    
cpu-avx512       Canonical Ltd      CPUs with AVX512                     no    
arm-neon         Canonical Ltd      ARM CPUs with NEON instruction set   no    
ampere-altra     Canonical Ltd      Test ampere selection                no    
ampere           Canonical Ltd      Test ampere selection                no 
```