### PR TITLE
Remove friendly names from cached machine info

### DIFF
--- a/pkg/storage/cache.go
+++ b/pkg/storage/cache.go
@@ -85,7 +85,7 @@ func (c *cache) GetMachineInfo() (*types.HwInfo, error) {
 }
 
 func (c *cache) loadMachineInfo() (*types.HwInfo, error) {
-	machine, err := hardware_info.Get(true)
+	machine, err := hardware_info.Get(false)
 	if err != nil {
 		return nil, fmt.Errorf("error getting machine info: %v", err)
 	}


### PR DESCRIPTION
Related:
* Resolves canonical/inference-snaps#151 
* This does NOT solve canonical/inference-snaps#148 

