### PR TITLE
Consistent error reporting

### DIFF
--- a/cmd/cli/commands/chat.go
+++ b/cmd/cli/commands/chat.go
@@ -37,7 +37,7 @@ func ChatEnabled() bool {
 func (cmd *chatCommand) run(_ *cobra.Command, _ []string) error {
 	chatBaseUrl, err := chatBaseURL(cmd.Context)
 	if err != nil {
-		return fmt.Errorf("OpenAI base URL: %v", err)
+		return fmt.Errorf("%v", err)
 	}
 
 	if env.SnapInstanceName() != "" {
@@ -61,7 +61,7 @@ func (cmd *chatCommand) run(_ *cobra.Command, _ []string) error {
 func chatBaseURL(ctx *common.Context) (string, error) {
 	serverEndpoints, err := common.ServerEndpoints(ctx)
 	if err != nil {
-		return "", fmt.Errorf("server endpoints: %v", err)
+		return "", fmt.Errorf("%v", err)
 	}
 	chatBaseUrl, found := serverEndpoints[common.OpenAiEndpointKey]
 	if !found {

--- a/cmd/cli/commands/chat.go
+++ b/cmd/cli/commands/chat.go
@@ -37,7 +37,7 @@ func ChatEnabled() bool {
 func (cmd *chatCommand) run(_ *cobra.Command, _ []string) error {
 	chatBaseUrl, err := chatBaseURL(cmd.Context)
 	if err != nil {
-		return fmt.Errorf("error getting OpenAI base URL: %v", err)
+		return fmt.Errorf("OpenAI base URL: %v", err)
 	}
 
 	if env.SnapInstanceName() != "" {
@@ -45,7 +45,7 @@ func (cmd *chatCommand) run(_ *cobra.Command, _ []string) error {
 		serviceName := env.SnapInstanceName() + ".server"
 		services, err := snapctl.Services(serviceName).Run()
 		if err != nil {
-			return fmt.Errorf("error getting services: %v", err)
+			return fmt.Errorf("services: %v", err)
 		}
 		if services[serviceName].Current == "inactive" {
 			return fmt.Errorf("server not active\n\n%s",
@@ -61,7 +61,7 @@ func (cmd *chatCommand) run(_ *cobra.Command, _ []string) error {
 func chatBaseURL(ctx *common.Context) (string, error) {
 	serverEndpoints, err := common.ServerEndpoints(ctx)
 	if err != nil {
-		return "", fmt.Errorf("error getting server endpoints: %v", err)
+		return "", fmt.Errorf("server endpoints: %v", err)
 	}
 	chatBaseUrl, found := serverEndpoints[common.OpenAiEndpointKey]
 	if !found {

--- a/cmd/cli/commands/debug/select.go
+++ b/cmd/cli/commands/debug/select.go
@@ -54,12 +54,12 @@ func (cmd *selectCommand) run(_ *cobra.Command, args []string) error {
 
 	err := yaml.NewDecoder(os.Stdin).Decode(&hardwareInfo)
 	if err != nil {
-		return fmt.Errorf("error decoding hardware info: %s", err)
+		return fmt.Errorf("decoding hardware info: %s", err)
 	}
 
 	allEngines, err := engines.LoadManifests(cmd.enginesDir)
 	if err != nil {
-		return fmt.Errorf("error loading engines from directory: %s", err)
+		return fmt.Errorf("loading engines from directory: %s", err)
 	}
 
 	stopProgress := common.StartProgressSpinner(common.ProgressScoring)
@@ -67,7 +67,7 @@ func (cmd *selectCommand) run(_ *cobra.Command, args []string) error {
 
 	scoredEngines, err := selector.ScoreEngines(&hardwareInfo, allEngines)
 	if err != nil {
-		return fmt.Errorf("error checking engines: %s", err)
+		return fmt.Errorf("checking engines: %s", err)
 	}
 	stopProgress()
 
@@ -89,7 +89,7 @@ func (cmd *selectCommand) run(_ *cobra.Command, args []string) error {
 
 	selectedEngine, err := selector.TopEngine(scoredEngines)
 	if err != nil {
-		return fmt.Errorf("error finding top engine: %v", err)
+		return fmt.Errorf("finding top engine: %v", err)
 	}
 	engineSelection.TopEngine = selectedEngine.Name
 
@@ -101,13 +101,13 @@ func (cmd *selectCommand) run(_ *cobra.Command, args []string) error {
 	case "json":
 		jsonString, err := json.MarshalIndent(engineSelection, "", "  ")
 		if err != nil {
-			return fmt.Errorf("failed to marshal to JSON: %s", err)
+			return fmt.Errorf("json: %s", err)
 		}
 		resultStr = string(jsonString)
 	case "yaml":
 		yamlString, err := yaml.Marshal(engineSelection)
 		if err != nil {
-			return fmt.Errorf("failed to marshal to YAML: %s", err)
+			return fmt.Errorf("yaml: %s", err)
 		}
 		resultStr = string(yamlString)
 	default:

--- a/cmd/cli/commands/get.go
+++ b/cmd/cli/commands/get.go
@@ -52,7 +52,7 @@ func (cmd *getCommand) run(_ *cobra.Command, args []string) error {
 func (cmd *getCommand) getValue(key string) error {
 	value, err := cmd.Config.Get(key)
 	if err != nil {
-		return fmt.Errorf("error getting value of %q: %v", key, err)
+		return fmt.Errorf("getting value of %q: %v", key, err)
 	}
 
 	if len(value) == 0 {
@@ -65,7 +65,7 @@ func (cmd *getCommand) getValue(key string) error {
 		// print as yaml
 		yamlOutput, err := yaml.Marshal(value)
 		if err != nil {
-			return fmt.Errorf("error serializing value: %v", err)
+			return fmt.Errorf("serializing value: %v", err)
 		}
 		fmt.Printf("%s", yamlOutput) // the yaml output ends with a newline
 	}
@@ -81,7 +81,7 @@ func (cmd *getCommand) getValue(key string) error {
 func (cmd *getCommand) getValues() error {
 	values, err := cmd.Config.GetAll()
 	if err != nil {
-		return fmt.Errorf("error getting values: %v", err)
+		return fmt.Errorf("getting values: %v", err)
 	}
 
 	// Drop deprecated configurations. The user doesn't need to see them.
@@ -94,7 +94,7 @@ func (cmd *getCommand) getValues() error {
 	// print config value
 	yamlOutput, err := yaml.Marshal(values)
 	if err != nil {
-		return fmt.Errorf("error serializing values: %v", err)
+		return fmt.Errorf("serializing values: %v", err)
 	}
 	fmt.Printf("%s", yamlOutput) // the yaml output ends with a newline
 

--- a/cmd/cli/commands/get.go
+++ b/cmd/cli/commands/get.go
@@ -72,7 +72,7 @@ func (cmd *getCommand) getValue(key string) error {
 
 	// Warn the user about deprecated fields. These are still consumed by the engines.
 	if slices.Contains(deprecatedConfig, key) && utils.IsTerminalOutput() {
-		fmt.Fprintf(os.Stderr, "Note: %q configuration field is deprecated!\n", key)
+		fmt.Fprintf(os.Stderr, "Warning: %q configuration field is deprecated!\n", key)
 	}
 
 	return nil

--- a/cmd/cli/commands/list-engines.go
+++ b/cmd/cli/commands/list-engines.go
@@ -57,7 +57,7 @@ func (cmd *listEnginesCommand) run(_ *cobra.Command, _ []string) error {
 
 	scoredEngines, err := common.ScoreEngines(cmd.Context)
 	if err != nil {
-		return fmt.Errorf("checking engines: %v", err)
+		return fmt.Errorf("%v", err)
 	}
 	stopProgress()
 
@@ -78,12 +78,12 @@ func (cmd *listEnginesCommand) run(_ *cobra.Command, _ []string) error {
 	case "table":
 		err = cmd.printEnginesTable(enginesList)
 		if err != nil {
-			return fmt.Errorf("printing list: %v", err)
+			return fmt.Errorf("%v", err)
 		}
 	case "json":
 		err = cmd.printEnginesJson(enginesList)
 		if err != nil {
-			return fmt.Errorf("printing list: %v", err)
+			return fmt.Errorf("%v", err)
 		}
 	default:
 		return fmt.Errorf("unknown format %q", cmd.format)

--- a/cmd/cli/commands/list-engines.go
+++ b/cmd/cli/commands/list-engines.go
@@ -57,13 +57,13 @@ func (cmd *listEnginesCommand) run(_ *cobra.Command, _ []string) error {
 
 	scoredEngines, err := common.ScoreEngines(cmd.Context)
 	if err != nil {
-		return fmt.Errorf("error checking engines: %v", err)
+		return fmt.Errorf("checking engines: %v", err)
 	}
 	stopProgress()
 
 	activeEngine, err := cmd.Cache.GetActiveEngine()
 	if err != nil {
-		return fmt.Errorf("could not determine active engine: %v", err)
+		return fmt.Errorf("get active engine: %v", err)
 	}
 
 	enginesList := outputEngines{
@@ -78,12 +78,12 @@ func (cmd *listEnginesCommand) run(_ *cobra.Command, _ []string) error {
 	case "table":
 		err = cmd.printEnginesTable(enginesList)
 		if err != nil {
-			return fmt.Errorf("error printing list: %v", err)
+			return fmt.Errorf("printing list: %v", err)
 		}
 	case "json":
 		err = cmd.printEnginesJson(enginesList)
 		if err != nil {
-			return fmt.Errorf("error printing list: %v", err)
+			return fmt.Errorf("printing list: %v", err)
 		}
 	default:
 		return fmt.Errorf("unknown format %q", cmd.format)
@@ -95,7 +95,7 @@ func (cmd *listEnginesCommand) run(_ *cobra.Command, _ []string) error {
 func (cmd *listEnginesCommand) printEnginesJson(enginesList outputEngines) error {
 	jsonString, err := json.MarshalIndent(enginesList, "", "  ")
 	if err != nil {
-		return fmt.Errorf("error marshalling engines to json: %v", err)
+		return fmt.Errorf("json: %v", err)
 	}
 	fmt.Printf("%s\n", jsonString)
 	return nil
@@ -215,11 +215,11 @@ func (cmd *listEnginesCommand) printEnginesTable(enginesList outputEngines) erro
 	table.Header(tableRows[0])
 	err := table.Bulk(tableRows[1:])
 	if err != nil {
-		return fmt.Errorf("error adding data to table: %v", err)
+		return fmt.Errorf("adding data to table: %v", err)
 	}
 	err = table.Render()
 	if err != nil {
-		return fmt.Errorf("error rendering table: %v", err)
+		return fmt.Errorf("rendering table: %v", err)
 	}
 	return nil
 }

--- a/cmd/cli/commands/prune-cache.go
+++ b/cmd/cli/commands/prune-cache.go
@@ -55,9 +55,9 @@ func (cmd *pruneCacheCommand) run(_ *cobra.Command, _ []string) error {
 			if cmd.Verbose {
 				fmt.Println(err)
 			}
-			return fmt.Errorf("No active engine found")
+			return fmt.Errorf("no active engine found")
 		}
-		return fmt.Errorf("error loading engine manifest: %v", err)
+		return fmt.Errorf("loading engine manifest: %v", err)
 	}
 
 	var componentsWithEnginesToRemove map[string][]string
@@ -88,7 +88,7 @@ func (cmd *pruneCacheCommand) run(_ *cobra.Command, _ []string) error {
 				}
 				return fmt.Errorf("%q not found", cmd.engine)
 			}
-			return fmt.Errorf("error loading engine manifest: %v", err)
+			return fmt.Errorf("loading engine manifest: %v", err)
 		}
 
 		componentsWithEnginesToRemove, err = cmd.calculateRemovableComponents([]engines.Manifest{*engineManifest}, *activeEngineManifest)
@@ -135,7 +135,7 @@ func (cmd *pruneCacheCommand) calculateRemovableComponents(enginesToCheck []engi
 func (cmd *pruneCacheCommand) getAllComponentsToRemove(activeEngineManifest engines.Manifest) (map[string][]string, error) {
 	enginesToCheck, err := engines.LoadManifests(cmd.EnginesDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load manifests: %w", err)
+		return nil, fmt.Errorf("loading manifests: %w", err)
 	}
 	return cmd.calculateRemovableComponents(enginesToCheck, activeEngineManifest)
 }
@@ -154,7 +154,7 @@ func (cmd *pruneCacheCommand) pruneEngine(componentsToRemove []string, engine en
 
 	if len(installed) != 0 {
 		if err := snapctl.RemoveComponents(installed...).Run(); err != nil {
-			return fmt.Errorf("failed to remove components: %w", err)
+			return fmt.Errorf("removing components: %w", err)
 		}
 	}
 	return nil
@@ -168,7 +168,7 @@ func (cmd *pruneCacheCommand) pruneAllInactiveEngines(componentsToRemove []strin
 	var allEngines []engines.Manifest
 	allEngines, err = engines.LoadManifests(cmd.EnginesDir)
 	if err != nil {
-		return fmt.Errorf("failed to load manifests: %w", err)
+		return fmt.Errorf("loading manifests: %w", err)
 	}
 
 	for _, engine := range allEngines {
@@ -212,7 +212,7 @@ func (cmd *pruneCacheCommand) printComponentsAndConfirm(componentsWithEngines ma
 
 	engineList, err := cmd.inactiveEngines()
 	if err != nil {
-		return false, fmt.Errorf("unable to get list of inactive engines: %v", err)
+		return false, fmt.Errorf("getting list of inactive engines: %v", err)
 	}
 
 	var confirmationPromptSentence string

--- a/cmd/cli/commands/prune-cache.go
+++ b/cmd/cli/commands/prune-cache.go
@@ -191,7 +191,11 @@ func (cmd *pruneCacheCommand) printComponentsAndConfirm(componentsWithEngines ma
 
 		componentSizes, err := snap_store.ComponentSizes()
 		if err != nil {
-			fmt.Printf("Warning: unable to get component sizes: %v\n", err)
+			if cmd.Verbose {
+				fmt.Printf("Warning: unable to get component sizes: %v\n", err)
+			} else {
+				fmt.Printf("Warning: unable to get component sizes\n")
+			}
 		}
 
 		for componentName, engineNames := range componentsWithEngines {

--- a/cmd/cli/commands/run.go
+++ b/cmd/cli/commands/run.go
@@ -52,7 +52,7 @@ func (cmd *runCommand) run(_ *cobra.Command, args []string) error {
 
 	err := common.LoadEngineEnvironment(cmd.Context)
 	if err != nil {
-		return fmt.Errorf("loading engine environment: %v", err)
+		return fmt.Errorf("%v", err)
 	}
 
 	path := args[0]

--- a/cmd/cli/commands/run.go
+++ b/cmd/cli/commands/run.go
@@ -46,13 +46,13 @@ func (cmd *runCommand) run(_ *cobra.Command, args []string) error {
 
 	if cmd.waitForComponentsFlag {
 		if err := cmd.waitForComponents(); err != nil {
-			return fmt.Errorf("error waiting for component: %s", err)
+			return fmt.Errorf("%s", err)
 		}
 	}
 
 	err := common.LoadEngineEnvironment(cmd.Context)
 	if err != nil {
-		return fmt.Errorf("error loading engine environment: %v", err)
+		return fmt.Errorf("loading engine environment: %v", err)
 	}
 
 	path := args[0]
@@ -87,7 +87,7 @@ func (cmd *runCommand) waitForComponents() error {
 
 	activeEngineName, err := cmd.Cache.GetActiveEngine()
 	if err != nil {
-		return fmt.Errorf("error looking up active engine: %v", err)
+		return fmt.Errorf("getting active engine: %v", err)
 	}
 
 	if activeEngineName == "" {
@@ -96,7 +96,7 @@ func (cmd *runCommand) waitForComponents() error {
 
 	manifest, err := engines.LoadManifest(cmd.EnginesDir, activeEngineName)
 	if err != nil {
-		return fmt.Errorf("error loading engine manifest: %v", err)
+		return fmt.Errorf("loading engine manifest: %v", err)
 	}
 
 	missing, err := cmd.checkMissingComponents(manifest)
@@ -117,7 +117,7 @@ func (cmd *runCommand) waitForComponents() error {
 	}
 
 	if len(missing) > 0 {
-		return fmt.Errorf("timed out after %ds while waiting for required components: %s",
+		return fmt.Errorf("%ds timeout waiting for required components: %s",
 			maxWait, strings.Join(missing, ", "))
 	}
 

--- a/cmd/cli/commands/set.go
+++ b/cmd/cli/commands/set.go
@@ -79,7 +79,7 @@ func (cmd *setCommand) setValue(keyValue string) error {
 		err = cmd.Config.Set(key, value, storage.UserConfig)
 	}
 	if err != nil {
-		return fmt.Errorf("error setting value %q for %q: %v", value, key, err)
+		return fmt.Errorf("setting value %q for %q: %v", value, key, err)
 	}
 
 	return nil

--- a/cmd/cli/commands/set.go
+++ b/cmd/cli/commands/set.go
@@ -79,7 +79,7 @@ func (cmd *setCommand) setValue(keyValue string) error {
 		err = cmd.Config.Set(key, value, storage.UserConfig)
 	}
 	if err != nil {
-		return fmt.Errorf("setting value %q for %q: %v", value, key, err)
+		return fmt.Errorf("setting %q to %q: %v", key, value, err)
 	}
 
 	return nil

--- a/cmd/cli/commands/show-engine.go
+++ b/cmd/cli/commands/show-engine.go
@@ -60,7 +60,7 @@ func (cmd *showEngineCommand) run(_ *cobra.Command, args []string) error {
 func (cmd *showEngineCommand) validateArgs(_ *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
 	manifests, err := engines.LoadManifests(cmd.EnginesDir)
 	if err != nil {
-		fmt.Printf("Error loading engines: %v\n", err)
+		fmt.Printf("Error: loading engines: %v\n", err)
 		return nil, cobra.ShellCompDirectiveError
 	}
 
@@ -89,7 +89,7 @@ func (cmd *showEngineCommand) showEngine(engineName string) error {
 
 	scoredEngines, err := common.ScoreEngines(cmd.Context)
 	if err != nil {
-		return fmt.Errorf("checking engines: %v", err)
+		return fmt.Errorf("%v", err)
 	}
 	stopProgress()
 
@@ -105,7 +105,7 @@ func (cmd *showEngineCommand) showEngine(engineName string) error {
 
 	err = cmd.printEngineManifest(scoredManifest)
 	if err != nil {
-		return fmt.Errorf("engine manifest: %v", err)
+		return fmt.Errorf("%v", err)
 	}
 	return nil
 }

--- a/cmd/cli/commands/show-engine.go
+++ b/cmd/cli/commands/show-engine.go
@@ -75,7 +75,7 @@ func (cmd *showEngineCommand) validateArgs(_ *cobra.Command, args []string, toCo
 func (cmd *showEngineCommand) showCurrentEngine() error {
 	currentEngine, err := cmd.Cache.GetActiveEngine()
 	if err != nil {
-		return fmt.Errorf("could not get the active engine: %v", err)
+		return fmt.Errorf("get active engine: %v", err)
 	}
 	if currentEngine == "" {
 		return fmt.Errorf("no active engine")
@@ -89,7 +89,7 @@ func (cmd *showEngineCommand) showEngine(engineName string) error {
 
 	scoredEngines, err := common.ScoreEngines(cmd.Context)
 	if err != nil {
-		return fmt.Errorf("error checking engines: %v", err)
+		return fmt.Errorf("checking engines: %v", err)
 	}
 	stopProgress()
 
@@ -105,7 +105,7 @@ func (cmd *showEngineCommand) showEngine(engineName string) error {
 
 	err = cmd.printEngineManifest(scoredManifest)
 	if err != nil {
-		return fmt.Errorf("error printing engine manifest: %v", err)
+		return fmt.Errorf("engine manifest: %v", err)
 	}
 	return nil
 }
@@ -117,13 +117,13 @@ func (cmd *showEngineCommand) printEngineManifest(engine engines.ScoredManifest)
 	case "json":
 		jsonString, err := json.MarshalIndent(output, "", "  ")
 		if err != nil {
-			return fmt.Errorf("failed to marshal to JSON: %s", err)
+			return fmt.Errorf("json: %s", err)
 		}
 		fmt.Printf("%s\n", jsonString)
 	case "yaml", "":
 		engineYaml, err := yaml.Marshal(output)
 		if err != nil {
-			return fmt.Errorf("failed to marshal to YAML: %s", err)
+			return fmt.Errorf("yaml: %s", err)
 		}
 		fmt.Print(string(engineYaml))
 	default:

--- a/cmd/cli/commands/show-machine.go
+++ b/cmd/cli/commands/show-machine.go
@@ -46,20 +46,20 @@ func ShowMachine(ctx *common.Context) *cobra.Command {
 func (cmd *showMachineCommand) run(_ *cobra.Command, _ []string) error {
 	hwInfo, err := hardware_info.Get(true)
 	if err != nil {
-		return fmt.Errorf("failed to get machine info: %s", err)
+		return fmt.Errorf("machine info: %s", err)
 	}
 
 	switch cmd.format {
 	case "json":
 		jsonString, err := json.MarshalIndent(hwInfo, "", "  ")
 		if err != nil {
-			return fmt.Errorf("failed to marshal to JSON: %s", err)
+			return fmt.Errorf("json: %s", err)
 		}
 		fmt.Printf("%s\n", jsonString)
 	case "yaml":
 		yamlString, err := yaml.Marshal(hwInfo)
 		if err != nil {
-			return fmt.Errorf("failed to marshal to YAML: %s", err)
+			return fmt.Errorf("yaml: %s", err)
 		}
 		fmt.Printf("%s", yamlString)
 	default:

--- a/cmd/cli/commands/show-machine.go
+++ b/cmd/cli/commands/show-machine.go
@@ -46,7 +46,7 @@ func ShowMachine(ctx *common.Context) *cobra.Command {
 func (cmd *showMachineCommand) run(_ *cobra.Command, _ []string) error {
 	hwInfo, err := hardware_info.Get(true)
 	if err != nil {
-		return fmt.Errorf("machine info: %s", err)
+		return fmt.Errorf("%s", err)
 	}
 
 	switch cmd.format {

--- a/cmd/cli/commands/status.go
+++ b/cmd/cli/commands/status.go
@@ -76,7 +76,7 @@ func (cmd *statusCommand) run(_ *cobra.Command, _ []string) error {
 func (cmd *statusCommand) statusYaml() (string, error) {
 	statusStr, err := cmd.statusStruct()
 	if err != nil {
-		return "", fmt.Errorf("status: %v", err)
+		return "", fmt.Errorf("%v", err)
 	}
 	yamlStr, err := yaml.Marshal(statusStr)
 	if err != nil {
@@ -88,7 +88,7 @@ func (cmd *statusCommand) statusYaml() (string, error) {
 func (cmd *statusCommand) statusJson() (string, error) {
 	statusStr, err := cmd.statusStruct()
 	if err != nil {
-		return "", fmt.Errorf("status: %v", err)
+		return "", fmt.Errorf("%v", err)
 	}
 	jsonStr, err := json.MarshalIndent(statusStr, "", "  ")
 	if err != nil {
@@ -133,7 +133,7 @@ func (cmd *statusCommand) statusStruct() (*status, error) {
 
 	endpoints, err := common.ServerEndpoints(cmd.Context)
 	if err != nil {
-		return nil, fmt.Errorf("getting server api endpoints: %v", err)
+		return nil, fmt.Errorf("%v", err)
 	}
 	statusStr.Endpoints = endpoints
 

--- a/cmd/cli/commands/status.go
+++ b/cmd/cli/commands/status.go
@@ -54,13 +54,13 @@ func (cmd *statusCommand) run(_ *cobra.Command, _ []string) error {
 	case "json":
 		statusText, err = cmd.statusJson()
 		if err != nil {
-			return fmt.Errorf("error getting json status: %v", err)
+			return fmt.Errorf("%v", err)
 		}
 		statusText += "\n"
 	case "yaml":
 		statusText, err = cmd.statusYaml()
 		if err != nil {
-			return fmt.Errorf("error getting yaml status: %v", err)
+			return fmt.Errorf("%v", err)
 		}
 	default:
 		return fmt.Errorf("unknown format %q", cmd.format)
@@ -76,11 +76,11 @@ func (cmd *statusCommand) run(_ *cobra.Command, _ []string) error {
 func (cmd *statusCommand) statusYaml() (string, error) {
 	statusStr, err := cmd.statusStruct()
 	if err != nil {
-		return "", fmt.Errorf("error getting status: %v", err)
+		return "", fmt.Errorf("status: %v", err)
 	}
 	yamlStr, err := yaml.Marshal(statusStr)
 	if err != nil {
-		return "", fmt.Errorf("error marshalling yaml: %v", err)
+		return "", fmt.Errorf("yaml: %v", err)
 	}
 	return string(yamlStr), nil
 }
@@ -88,11 +88,11 @@ func (cmd *statusCommand) statusYaml() (string, error) {
 func (cmd *statusCommand) statusJson() (string, error) {
 	statusStr, err := cmd.statusStruct()
 	if err != nil {
-		return "", fmt.Errorf("error getting status: %v", err)
+		return "", fmt.Errorf("status: %v", err)
 	}
 	jsonStr, err := json.MarshalIndent(statusStr, "", "  ")
 	if err != nil {
-		return "", fmt.Errorf("error marshalling json: %v", err)
+		return "", fmt.Errorf("json: %v", err)
 	}
 	return string(jsonStr), nil
 }
@@ -108,23 +108,23 @@ func (cmd *statusCommand) statusStruct() (*status, error) {
 
 	activeEngineName, err := cmd.Cache.GetActiveEngine()
 	if err != nil {
-		return nil, fmt.Errorf("error getting active engine: %v", err)
+		return nil, fmt.Errorf("getting active engine: %v", err)
 	}
 	if activeEngineName == "" {
-		return nil, fmt.Errorf("error no engine is active")
+		return nil, fmt.Errorf("no engine is active")
 	}
 	statusStr.Engine = activeEngineName
 
 	services, err := snapctl.Services().Run()
 	if err != nil {
-		return nil, fmt.Errorf("error getting services: %v", err)
+		return nil, fmt.Errorf("getting services: %v", err)
 	}
 	statusStr.Services = make(map[string]string)
 	for name, service := range services {
 		// The service name is in the format <snap-name>.<service-app>, we only want the service-app part.
 		_, serviceApp, found := strings.Cut(name, ".")
 		if !found {
-			return nil, fmt.Errorf("error unexpected service name format: %q", name)
+			return nil, fmt.Errorf("unexpected service name format: %q", name)
 		}
 		// Append the service status exactly as snapd reports it. Often this is in the host system language, see bug:
 		// https://bugs.launchpad.net/snapd/+bug/2137543
@@ -133,7 +133,7 @@ func (cmd *statusCommand) statusStruct() (*status, error) {
 
 	endpoints, err := common.ServerEndpoints(cmd.Context)
 	if err != nil {
-		return nil, fmt.Errorf("error getting server api endpoints: %v", err)
+		return nil, fmt.Errorf("getting server api endpoints: %v", err)
 	}
 	statusStr.Endpoints = endpoints
 

--- a/cmd/cli/commands/use-engine.go
+++ b/cmd/cli/commands/use-engine.go
@@ -305,7 +305,7 @@ func (cmd *useEngineCommand) fixActiveEngine() error {
 func (cmd *useEngineCommand) installMissingComponents(engine *engines.Manifest) (installed bool, err error) {
 	missingComponents, err := cmd.missingComponents(engine.Components)
 	if err != nil {
-		return false, fmt.Errorf("checking installed components: %v", err)
+		return false, fmt.Errorf("%v", err)
 	}
 	if len(missingComponents) == 0 {
 		return false, nil
@@ -315,7 +315,11 @@ func (cmd *useEngineCommand) installMissingComponents(engine *engines.Manifest) 
 	componentSizes, err := snap_store.ComponentSizes()
 	if err != nil {
 		// If component size lookup failed, continue but log the error
-		fmt.Fprintf(os.Stderr, "Warning: unable to get component sizes: %v\n", err)
+		if cmd.Verbose {
+			fmt.Fprintf(os.Stderr, "Warning: unable to get component sizes: %v\n", err)
+		} else {
+			fmt.Fprintf(os.Stderr, "Warning: unable to get component sizes")
+		}
 	}
 
 	// Format list of components, adding size if it is known

--- a/cmd/cli/commands/use-engine.go
+++ b/cmd/cli/commands/use-engine.go
@@ -95,7 +95,7 @@ func (cmd *useEngineCommand) autoSelectEngine() error {
 
 	scoredEngines, err := common.ScoreEngines(cmd.Context)
 	if err != nil {
-		return fmt.Errorf("error checking engines: %v", err)
+		return fmt.Errorf("checking engines: %v", err)
 	}
 	stopProgress()
 
@@ -120,14 +120,14 @@ func (cmd *useEngineCommand) autoSelectEngine() error {
 
 	selectedEngine, err := selector.TopEngine(scoredEngines)
 	if err != nil {
-		return fmt.Errorf("error finding top engine: %v", err)
+		return fmt.Errorf("finding top engine: %v", err)
 	}
 
 	fmt.Printf("Selected engine: %s\n", selectedEngine.Name)
 
 	err = cmd.switchEngine(selectedEngine.Name)
 	if err != nil {
-		return fmt.Errorf("failed to use engine: %s", err)
+		return fmt.Errorf("using engine: %s", err)
 	}
 
 	return nil
@@ -142,19 +142,19 @@ func (cmd *useEngineCommand) switchEngine(engineName string) error {
 			if cmd.Verbose {
 				fmt.Println(err)
 			}
-			return fmt.Errorf("%q not found", engineName)
+			return fmt.Errorf("engine %q not found", engineName)
 		}
-		return fmt.Errorf("error loading engine manifest: %v", err)
+		return fmt.Errorf("loading engine manifest: %v", err)
 	}
 
 	componentsInstalled, err := cmd.installMissingComponents(engine)
 	if err != nil {
-		return fmt.Errorf("error installing missing components: %v", err)
+		return fmt.Errorf("installing missing components: %v", err)
 	}
 
 	activeEngineName, err := cmd.Cache.GetActiveEngine()
 	if err != nil {
-		return fmt.Errorf("error getting active engine: %v", err)
+		return fmt.Errorf("getting active engine: %v", err)
 	}
 
 	if activeEngineName == engineName {
@@ -166,7 +166,7 @@ func (cmd *useEngineCommand) switchEngine(engineName string) error {
 	if activeEngineName != "" {
 		err = common.UnsetEngineConfig(activeEngineName, true, cmd.Context)
 		if err != nil {
-			return fmt.Errorf("error un-setting engine configurations: %v", err)
+			return fmt.Errorf("un-setting engine configurations: %v", err)
 		}
 	}
 
@@ -176,11 +176,11 @@ func (cmd *useEngineCommand) switchEngine(engineName string) error {
 	}
 
 	if err = cmd.Cache.SetActiveEngine(engine.Name); err != nil {
-		return fmt.Errorf("error setting active engine: %v", err)
+		return fmt.Errorf("setting active engine: %v", err)
 	}
 
 	if err = common.SetEngineConfig(engine, cmd.Context); err != nil {
-		return fmt.Errorf("error setting new engine configurations: %v", err)
+		return fmt.Errorf("setting new engine configurations: %v", err)
 	}
 
 	fmt.Printf("Engine changed to %q.\n", engineName)
@@ -259,7 +259,7 @@ func (*useEngineCommand) installComponents(components []string) error {
 
 			} else {
 				// Any other error we do not specifically handle will stop installing components
-				return fmt.Errorf("error installing %q: %s", component, err)
+				return fmt.Errorf("installing %q: %s", component, err)
 			}
 		}
 
@@ -273,7 +273,7 @@ func (*useEngineCommand) installComponents(components []string) error {
 func (cmd *useEngineCommand) fixActiveEngine() error {
 	activeEngineName, err := cmd.Cache.GetActiveEngine()
 	if err != nil {
-		return fmt.Errorf("error getting active engine: %v", err)
+		return fmt.Errorf("getting active engine: %v", err)
 	}
 	if activeEngineName == "" {
 		return fmt.Errorf("no active engine to fix")
@@ -285,18 +285,18 @@ func (cmd *useEngineCommand) fixActiveEngine() error {
 		fmt.Printf("Active engine %q not found, performing auto selection instead.\n", activeEngineName)
 		return cmd.autoSelectEngine()
 	} else if err != nil {
-		return fmt.Errorf("error loading active engine manifest: %v", err)
+		return fmt.Errorf("loading active engine manifest: %v", err)
 	}
 
 	// If engine exists, make sure it is correctly installed and configured
 	if _, err = cmd.installMissingComponents(engine); err != nil {
-		return fmt.Errorf("error installing missing components: %v", err)
+		return fmt.Errorf("installing missing components: %v", err)
 	}
 	if err = common.UnsetEngineConfig(activeEngineName, false, cmd.Context); err != nil {
-		return fmt.Errorf("error un-setting engine configurations: %v", err)
+		return fmt.Errorf("un-setting engine configurations: %v", err)
 	}
 	if err = common.SetEngineConfig(engine, cmd.Context); err != nil {
-		return fmt.Errorf("error setting engine configurations: %v", err)
+		return fmt.Errorf("setting engine configurations: %v", err)
 	}
 
 	return nil
@@ -305,7 +305,7 @@ func (cmd *useEngineCommand) fixActiveEngine() error {
 func (cmd *useEngineCommand) installMissingComponents(engine *engines.Manifest) (installed bool, err error) {
 	missingComponents, err := cmd.missingComponents(engine.Components)
 	if err != nil {
-		return false, fmt.Errorf("error checking installed components: %v", err)
+		return false, fmt.Errorf("checking installed components: %v", err)
 	}
 	if len(missingComponents) == 0 {
 		return false, nil
@@ -344,7 +344,7 @@ func (cmd *useEngineCommand) installMissingComponents(engine *engines.Manifest) 
 	// https://github.com/canonical/inference-snaps-cli/issues/122
 	err = cmd.installComponents(missingComponents)
 	if err != nil {
-		return false, fmt.Errorf("error installing components: %v", err)
+		return false, fmt.Errorf("installing components: %v", err)
 	}
 
 	return true, nil

--- a/cmd/cli/commands/use-engine.go
+++ b/cmd/cli/commands/use-engine.go
@@ -53,7 +53,7 @@ func UseEngine(ctx *common.Context) *cobra.Command {
 func (cmd *useEngineCommand) validateArgs(_ *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
 	manifests, err := engines.LoadManifests(cmd.EnginesDir)
 	if err != nil {
-		fmt.Printf("Error loading engines: %v\n", err)
+		fmt.Printf("Error: loading engines: %v\n", err)
 		return nil, cobra.ShellCompDirectiveError
 	}
 
@@ -95,7 +95,7 @@ func (cmd *useEngineCommand) autoSelectEngine() error {
 
 	scoredEngines, err := common.ScoreEngines(cmd.Context)
 	if err != nil {
-		return fmt.Errorf("checking engines: %v", err)
+		return fmt.Errorf("%v", err)
 	}
 	stopProgress()
 
@@ -127,7 +127,7 @@ func (cmd *useEngineCommand) autoSelectEngine() error {
 
 	err = cmd.switchEngine(selectedEngine.Name)
 	if err != nil {
-		return fmt.Errorf("using engine: %s", err)
+		return fmt.Errorf("%s", err)
 	}
 
 	return nil
@@ -149,7 +149,7 @@ func (cmd *useEngineCommand) switchEngine(engineName string) error {
 
 	componentsInstalled, err := cmd.installMissingComponents(engine)
 	if err != nil {
-		return fmt.Errorf("installing missing components: %v", err)
+		return fmt.Errorf("%v", err)
 	}
 
 	activeEngineName, err := cmd.Cache.GetActiveEngine()
@@ -166,7 +166,7 @@ func (cmd *useEngineCommand) switchEngine(engineName string) error {
 	if activeEngineName != "" {
 		err = common.UnsetEngineConfig(activeEngineName, true, cmd.Context)
 		if err != nil {
-			return fmt.Errorf("un-setting engine configurations: %v", err)
+			return fmt.Errorf("%v", err)
 		}
 	}
 
@@ -180,7 +180,7 @@ func (cmd *useEngineCommand) switchEngine(engineName string) error {
 	}
 
 	if err = common.SetEngineConfig(engine, cmd.Context); err != nil {
-		return fmt.Errorf("setting new engine configurations: %v", err)
+		return fmt.Errorf("%v", err)
 	}
 
 	fmt.Printf("Engine changed to %q.\n", engineName)
@@ -290,13 +290,13 @@ func (cmd *useEngineCommand) fixActiveEngine() error {
 
 	// If engine exists, make sure it is correctly installed and configured
 	if _, err = cmd.installMissingComponents(engine); err != nil {
-		return fmt.Errorf("installing missing components: %v", err)
+		return fmt.Errorf("%v", err)
 	}
 	if err = common.UnsetEngineConfig(activeEngineName, false, cmd.Context); err != nil {
-		return fmt.Errorf("un-setting engine configurations: %v", err)
+		return fmt.Errorf("%v", err)
 	}
 	if err = common.SetEngineConfig(engine, cmd.Context); err != nil {
-		return fmt.Errorf("setting engine configurations: %v", err)
+		return fmt.Errorf("%v", err)
 	}
 
 	return nil
@@ -344,7 +344,7 @@ func (cmd *useEngineCommand) installMissingComponents(engine *engines.Manifest) 
 	// https://github.com/canonical/inference-snaps-cli/issues/122
 	err = cmd.installComponents(missingComponents)
 	if err != nil {
-		return false, fmt.Errorf("installing components: %v", err)
+		return false, fmt.Errorf("%v", err)
 	}
 
 	return true, nil

--- a/cmd/cli/commands/version.go
+++ b/cmd/cli/commands/version.go
@@ -55,13 +55,13 @@ func (cmd *versionCommand) run(_ *cobra.Command, _ []string) error {
 	case "json":
 		jsonString, err := json.MarshalIndent(versionData, "", "  ")
 		if err != nil {
-			return fmt.Errorf("failed to marshal to JSON: %s", err)
+			return fmt.Errorf("json: %s", err)
 		}
 		fmt.Printf("%s\n", jsonString)
 	case "yaml":
 		yamlString, err := yaml.Marshal(versionData)
 		if err != nil {
-			return fmt.Errorf("failed to marshal to YAML: %s", err)
+			return fmt.Errorf("yaml: %s", err)
 		}
 		fmt.Printf("%s", yamlString)
 	default:

--- a/cmd/cli/common/chat.go
+++ b/cmd/cli/common/chat.go
@@ -81,7 +81,7 @@ func (c *chatClient) Start() error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("error initializing readline: %v", err)
+		return fmt.Errorf("initializing readline: %v", err)
 	}
 	defer rl.Close()
 	//rl.CaptureExitSignal() // Should readline capture and handle the exit signal? - Can be used to interrupt the chat response stream.
@@ -246,7 +246,7 @@ func (c *chatClient) lookupModelName() error {
 			for _, model := range modelPage.Data {
 				names = append(names, model.ID)
 			}
-			return fmt.Errorf("expected one but server returned multiple models: %s", strings.Join(names, ", "))
+			return fmt.Errorf("server returned multiple models; expected one: %s", strings.Join(names, ", "))
 		}
 
 		c.modelName = modelPage.Data[0].ID

--- a/cmd/cli/common/component.go
+++ b/cmd/cli/common/component.go
@@ -17,7 +17,7 @@ func ComponentInstalled(component string) (bool, error) {
 		if os.IsNotExist(err) {
 			return false, nil
 		} else {
-			return false, fmt.Errorf("error checking component directory %q: %v", component, err)
+			return false, fmt.Errorf("checking component directory %q: %v", component, err)
 		}
 	} else {
 		if info.IsDir() {

--- a/cmd/cli/common/component.go
+++ b/cmd/cli/common/component.go
@@ -17,7 +17,7 @@ func ComponentInstalled(component string) (bool, error) {
 		if os.IsNotExist(err) {
 			return false, nil
 		} else {
-			return false, fmt.Errorf("checking component directory %q: %v", component, err)
+			return false, fmt.Errorf("checking installed component directory %q: %v", component, err)
 		}
 	} else {
 		if info.IsDir() {

--- a/cmd/cli/common/endpoints.go
+++ b/cmd/cli/common/endpoints.go
@@ -15,7 +15,7 @@ const (
 func ServerEndpoints(ctx *Context) (map[string]string, error) {
 	settings, err := EngineComponentSettings(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("loading engine environment: %v", err)
+		return nil, fmt.Errorf("%v", err)
 	}
 	return serverEndpoints(ctx, settings)
 }
@@ -37,7 +37,7 @@ func serverEndpoints(ctx *Context, settingsCollection []ComponentSettings) (map[
 			case "http", "https":
 				httpUrl, err := serverHttpUrl(ctx, serverSettings)
 				if err != nil {
-					return nil, fmt.Errorf("error getting server HTTP URL: %v", err)
+					return nil, fmt.Errorf("%v", err)
 				}
 				endpoints[serverName] = httpUrl
 			default:
@@ -58,7 +58,7 @@ func serverHttpUrl(ctx *Context, serverConfig map[string]string) (string, error)
 
 	httpPortMap, err := ctx.Config.Get(confHttpPort)
 	if err != nil {
-		return "", fmt.Errorf("error getting %q: %v", confHttpPort, err)
+		return "", fmt.Errorf("getting %q: %v", confHttpPort, err)
 	}
 	httpPort := httpPortMap[confHttpPort]
 

--- a/cmd/cli/common/endpoints.go
+++ b/cmd/cli/common/endpoints.go
@@ -15,7 +15,7 @@ const (
 func ServerEndpoints(ctx *Context) (map[string]string, error) {
 	settings, err := EngineComponentSettings(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error loading engine environment: %v", err)
+		return nil, fmt.Errorf("loading engine environment: %v", err)
 	}
 	return serverEndpoints(ctx, settings)
 }

--- a/cmd/cli/common/engine.go
+++ b/cmd/cli/common/engine.go
@@ -28,7 +28,7 @@ type ComponentSettings struct {
 func EngineComponentSettings(ctx *Context) ([]ComponentSettings, error) {
 	activeEngineName, err := ctx.Cache.GetActiveEngine()
 	if err != nil {
-		return nil, fmt.Errorf("error looking up active engine: %v", err)
+		return nil, fmt.Errorf("looking up active engine: %v", err)
 	}
 
 	if activeEngineName == "" {
@@ -37,7 +37,7 @@ func EngineComponentSettings(ctx *Context) ([]ComponentSettings, error) {
 
 	manifest, err := engines.LoadManifest(ctx.EnginesDir, activeEngineName)
 	if err != nil {
-		return nil, fmt.Errorf("error loading engine manifest: %v", err)
+		return nil, fmt.Errorf("loading engine manifest: %v", err)
 	}
 
 	componentsDir, found := os.LookupEnv("SNAP_COMPONENTS")
@@ -52,13 +52,13 @@ func EngineComponentSettings(ctx *Context) ([]ComponentSettings, error) {
 
 		data, err := os.ReadFile(componentYamlFile)
 		if err != nil {
-			return nil, fmt.Errorf("error reading %s: %v", componentYamlFile, err)
+			return nil, fmt.Errorf("reading %s: %v", componentYamlFile, err)
 		}
 
 		var settings ComponentSettings
 		err = yaml.Unmarshal(data, &settings)
 		if err != nil {
-			return nil, fmt.Errorf("error unmarshaling %s: %v", componentYamlFile, err)
+			return nil, fmt.Errorf("unmarshaling %s: %v", componentYamlFile, err)
 		}
 
 		settings.componentName = componentName
@@ -73,7 +73,7 @@ func EngineComponentSettings(ctx *Context) ([]ComponentSettings, error) {
 func LoadEngineEnvironment(ctx *Context) error {
 	settingsCollection, err := EngineComponentSettings(ctx)
 	if err != nil {
-		return fmt.Errorf("error loading engine component settings: %v", err)
+		return fmt.Errorf("loading engine component settings: %v", err)
 	}
 
 	componentsDir, found := os.LookupEnv("SNAP_COMPONENTS")
@@ -94,7 +94,7 @@ func LoadEngineEnvironment(ctx *Context) error {
 			// Set component path env var for expansion
 			componentPath := filepath.Join(componentsDir, settings.componentName)
 			if err := os.Setenv(componentEnv, componentPath); err != nil {
-				return fmt.Errorf("error setting %q: %v", componentEnv, err)
+				return fmt.Errorf("setting %q: %v", componentEnv, err)
 			}
 
 			// Expand all env vars in value
@@ -102,12 +102,12 @@ func LoadEngineEnvironment(ctx *Context) error {
 
 			// Unset the component path
 			if err := os.Unsetenv(componentEnv); err != nil {
-				return fmt.Errorf("error unsetting %q: %v", componentEnv, err)
+				return fmt.Errorf("unsetting %q: %v", componentEnv, err)
 			}
 
 			err = os.Setenv(k, v)
 			if err != nil {
-				return fmt.Errorf("error setting %q: %v", k, err)
+				return fmt.Errorf("setting %q: %v", k, err)
 			}
 		}
 
@@ -122,7 +122,7 @@ func SetEngineConfig(engine *engines.Manifest, ctx *Context) error {
 	for confKey, confVal := range engine.Configurations {
 		err := ctx.Config.SetDocument(confKey, confVal, storage.EngineConfig)
 		if err != nil {
-			return fmt.Errorf("error setting engine configuration %q: %v", confKey, err)
+			return fmt.Errorf("setting engine configuration %q: %v", confKey, err)
 		}
 	}
 	return nil
@@ -132,7 +132,7 @@ func UnsetEngineConfig(engineName string, unsetUserOverrides bool, ctx *Context)
 	// Unset all engine configurations
 	err := ctx.Config.Unset(".", storage.EngineConfig)
 	if err != nil {
-		return fmt.Errorf("error un-setting engine configurations: %v", err)
+		return fmt.Errorf("un-setting engine configurations: %v", err)
 	}
 
 	if unsetUserOverrides {
@@ -144,13 +144,13 @@ func UnsetEngineConfig(engineName string, unsetUserOverrides bool, ctx *Context)
 				fmt.Fprintf(os.Stderr, "Warning: previously active engine %q not found; skipping user configuration cleanup.\n", engineName)
 				return nil
 			}
-			return fmt.Errorf("error loading engine manifest: %v", err)
+			return fmt.Errorf("loading engine manifest: %v", err)
 		} else {
 			// Unset any user overrides
 			for k := range engine.Configurations {
 				err = ctx.Config.Unset(k, storage.UserConfig)
 				if err != nil {
-					return fmt.Errorf("error un-setting configuration %q: %v", k, err)
+					return fmt.Errorf("un-setting configuration %q: %v", k, err)
 				}
 			}
 		}
@@ -168,17 +168,17 @@ Warning: calls to this function can block for a number of seconds while the host
 func ScoreEngines(ctx *Context) ([]engines.ScoredManifest, error) {
 	allEngines, err := engines.LoadManifests(ctx.EnginesDir)
 	if err != nil {
-		return nil, fmt.Errorf("error loading engines: %v", err)
+		return nil, fmt.Errorf("loading engines: %v", err)
 	}
 
 	machineInfo, err := hardware_info.Get(false)
 	if err != nil {
-		return nil, fmt.Errorf("error getting machine info: %v", err)
+		return nil, fmt.Errorf("machine info: %v", err)
 	}
 
 	scoredEngines, err := selector.ScoreEngines(machineInfo, allEngines)
 	if err != nil {
-		return nil, fmt.Errorf("error scoring engines: %v", err)
+		return nil, fmt.Errorf("scoring engines: %v", err)
 	}
 
 	return scoredEngines, nil

--- a/cmd/cli/common/engine.go
+++ b/cmd/cli/common/engine.go
@@ -73,7 +73,7 @@ func EngineComponentSettings(ctx *Context) ([]ComponentSettings, error) {
 func LoadEngineEnvironment(ctx *Context) error {
 	settingsCollection, err := EngineComponentSettings(ctx)
 	if err != nil {
-		return fmt.Errorf("loading engine component settings: %v", err)
+		return fmt.Errorf("%v", err)
 	}
 
 	componentsDir, found := os.LookupEnv("SNAP_COMPONENTS")

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -143,7 +143,7 @@ func appendCommandToGroup(rootCmd *cobra.Command, groupID string, cmd *cobra.Com
 			return nil
 		}
 	}
-	return fmt.Errorf("group with ID %q not found", groupID)
+	return fmt.Errorf("command group with ID %q not found", groupID)
 }
 
 // addCommands adds commands to the root command without a group

--- a/errors-summary.md
+++ b/errors-summary.md
@@ -1,0 +1,968 @@
+# inference-snaps-cli — Complete Error Reference
+
+All errors produced by first-party code, with their **full literal output** as seen by the user.
+Errors from external packages are the boundary; they are listed as the leaf cause but not traced further.
+
+## How cobra formats errors
+
+`SilenceUsage: true` is set on the root command; `SilenceErrors` is **not** set.
+Every error returned by a `RunE` (or `PersistentPreRunE`) function is printed to **stderr** by cobra as:
+
+```
+Error: <err.Error()>
+```
+
+followed, only when a command/flag parse fails (not a `RunE` error), by:
+
+```
+Run '<command> --help' for usage.
+```
+
+Errors printed directly with `fmt.Printf`/`fmt.Fprintf` are noted explicitly. All other entries in
+this document represent errors that cobra prefixes with `Error: `.
+
+---
+
+## Table of Contents
+1. [cmd/cli/main.go](#1-cmdclimaingo)
+2. [cmd/cli/commands/](#2-cmdclicommands)
+    - [use-engine.go](#21-use-enginego)
+    - [list-engines.go](#22-list-enginesgo)
+    - [show-engine.go](#23-show-enginego)
+    - [status.go](#24-statusgo)
+    - [chat.go](#25-chatgo)
+    - [get.go](#26-getgo)
+    - [set.go](#27-setgo)
+    - [prune-cache.go](#28-prune-cachego)
+    - [run.go](#29-rungo)
+    - [show-machine.go](#210-show-machinego)
+    - [version.go](#211-versiongo)
+    - [debug/validate.go](#212-debugvalidatego)
+    - [debug/select.go](#213-debugselectgo)
+    - [debug/chat.go](#214-debugchatgo)
+3. [cmd/cli/common/](#3-cmdclicommon)
+    - [engine.go](#31-enginego)
+    - [endpoints.go](#32-endpointsgo)
+    - [component.go](#33-componentgo)
+    - [errors.go](#34-errorsgo)
+4. [pkg/engines/](#4-pkgengines)
+    - [load.go](#41-loadgo)
+    - [validate.go](#42-validatego)
+    - [devices.go](#43-devicesgo)
+    - [busses.go](#44-bussesgo)
+    - [cpu.go](#45-cpugo)
+5. [pkg/selector/](#5-pkgselector)
+    - [select_stack.go](#51-select_stackgo)
+    - [pci/pci.go](#52-pcipci-go)
+    - [pci/properties.go](#53-pcipropertiesgo)
+6. [pkg/hardware_info/](#6-pkghardware_info)
+    - [hardware-info.go](#61-hardware-infogo)
+    - [memory/](#62-memory)
+    - [cpu/](#63-cpu)
+    - [disk/](#64-disk)
+    - [pci/pci_devices.go](#65-pcipci_devicesgo)
+    - [pci/lspci.go](#66-pcilspcigo)
+    - [pci/nvidia/](#67-pcinvidia)
+    - [pci/amd/](#68-pciamd)
+    - [pci/intel/](#69-pciintel)
+7. [pkg/snap_store/snap_store.go](#7-pkgsnap_storesnap_storego)
+8. [pkg/storage/](#8-pkgstorage)
+    - [cache.go](#81-cachego)
+    - [config.go](#82-configgo)
+    - [snapctl_storage.go](#83-snapctl_storagego)
+9. [pkg/utils/utils.go](#9-pkgutilsutilsgo)
+
+---
+
+## 1. `cmd/cli/main.go`
+
+These are printed **directly** with `fmt.Printf` (not through cobra), so there is no cobra `Error:` prefix added — but the strings themselves include `"Error: "`.
+
+| Full stdout output | Condition |
+|---|---|
+| `Error: could not retrieve snap services: <snapctl error>` | `snapctl.Services().Run()` fails at startup; printed to stdout then `return` |
+| `Error: <err>` | `appendCommandToGroup` fails (group ID `"basic"` not found — programming invariant); printed to stdout then `return` |
+
+`PersistentPreRunE` can return one error (cobra then prints it to stderr):
+
+| Full stderr output | Condition |
+|---|---|
+| `Error: <os.Setenv error>` | `os.Setenv("VERBOSE", "true")` fails when `--verbose` is passed |
+
+---
+
+## 2. `cmd/cli/commands/`
+
+### 2.1 `use-engine.go`
+
+> Shell-completion helper `validateArgs` prints directly to **stdout** (not through cobra RunE):
+> `Error: loading engines: <LoadManifests error>`
+
+#### `run()` — returned to cobra → stderr
+
+| Full stderr output | Condition |
+|---|---|
+| `Error: permission denied, try again with sudo` | Not root user |
+| `Error: cannot specify both engine name and --auto flag` | `--auto` used with a positional argument |
+| `Error: cannot specify both engine name and --fix flag` | `--fix` used with a positional argument |
+| `Error: engine name not specified` | No `--auto`, no `--fix`, and no positional argument |
+
+#### `autoSelectEngine()` → propagated to `run()` → stderr
+
+| Full stderr output | Condition |
+|---|---|
+| `Error: loading engines: <LoadManifests error>` | `engines.LoadManifests` fails — see [§4.1](#41-loadgo) |
+| `Error: machine info: <hardware_info.Get error>` | `hardware_info.Get` fails — see [§6.1](#61-hardware-infogo) |
+| `Error: scoring engines: <ScoreEngines error>` | `selector.ScoreEngines` fails — see [§5.1](#51-select_stackgo) |
+| `Error: finding top engine: no compatible engines found` | No stable, compatible engine exists |
+| `Error: engine "<name>" not found` | Named engine manifest missing (ErrManifestNotFound) |
+| `Error: loading engine manifest: <OS/YAML error>` | Other error reading the engine manifest |
+| `Error: checking installed components: checking installed component directory "<comp>": <os error>` | `os.Stat` on a component directory fails with non-ErrNotExist |
+| `Error: checking installed components: component "<comp>" exists but is not a directory` | Component path exists but is a regular file |
+| `Error: timed out while installing "<comp>":\nMonitor the installation progress with "snap changes"\n\nRerun this command once the installation is complete` | Component not fully installed within 60-minute timeout |
+| `Error: snap not known to the store:\nRerun this command after manually installing "<comp>"` | snapctl reports the snap is unknown to the store |
+| `Error: installing "<comp>": <snapctl error>` | Any other unhandled `snapctl.InstallComponents` error |
+| `Error: getting active engine: <snapctl error>` | `Cache.GetActiveEngine()` fails |
+| `Error: un-setting engine configurations: <snapctl error>` | `Config.Unset(".", EngineConfig)` fails |
+| `Error: loading engine manifest: <OS/YAML error>` | Manifest load error inside `UnsetEngineConfig` (when `unsetUserOverrides=true`) |
+| `Error: un-setting configuration "<key>": <snapctl error>` | `Config.Unset(k, UserConfig)` fails for a key |
+| `Error: setting active engine: <snapctl error>` | `Cache.SetActiveEngine` fails |
+| `Error: setting engine configuration "<key>": <snapctl error>` | `Config.SetDocument` fails |
+
+#### `fixActiveEngine()` → propagated to `run()` → stderr
+
+| Full stderr output | Condition |
+|---|---|
+| `Error: getting active engine: <snapctl error>` | `Cache.GetActiveEngine()` fails |
+| `Error: no active engine to fix` | Active engine name is empty |
+| `Error: loading active engine manifest: <OS/YAML error>` | Other manifest load error (non-ErrManifestNotFound) |
+| *(all autoSelectEngine or switchEngine errors above)* | ErrManifestNotFound → autoSelectEngine; other errors from installMissingComponents / UnsetEngineConfig / SetEngineConfig |
+
+#### Non-fatal, printed directly to stderr (no cobra prefix)
+
+| Full stderr output | Condition |
+|---|---|
+| `Warning: unable to get component sizes: <snap_store error>` | `snap_store.ComponentSizes()` fails **and** `--verbose` is set |
+| `Warning: unable to get component sizes` | `snap_store.ComponentSizes()` fails **and** `--verbose` is **not** set |
+
+---
+
+### 2.2 `list-engines.go`
+
+| Full stderr output | Condition |
+|---|---|
+| `Error: loading engines: <LoadManifests error>` | `engines.LoadManifests` fails — see [§4.1](#41-loadgo) |
+| `Error: machine info: <hardware_info.Get error>` | `hardware_info.Get` fails — see [§6.1](#61-hardware-infogo) |
+| `Error: scoring engines: <ScoreEngines error>` | `selector.ScoreEngines` fails — see [§5.1](#51-select_stackgo) |
+| `Error: get active engine: <snapctl error>` | `Cache.GetActiveEngine()` fails |
+| `Error: unknown format "<value>"` | `--format` value is not `"table"` or `"json"` |
+| `Error: json: <json error>` | `json.MarshalIndent` fails (internal invariant) |
+| `Error: adding data to table: <tablewriter error>` | `tablewriter.Bulk` fails (external library) |
+| `Error: rendering table: <tablewriter error>` | `tablewriter.Render` fails (external library) |
+
+Non-fatal, printed directly to stderr:
+
+| Full stderr output | Condition |
+|---|---|
+| `No engines found.` | Engine list is empty |
+
+---
+
+### 2.3 `show-engine.go`
+
+> Shell-completion helper `validateArgs` prints directly to **stdout** (not through cobra RunE):
+> `Error: loading engines: <LoadManifests error>`
+
+| Full stderr output | Condition |
+|---|---|
+| `Error: get active engine: <snapctl error>` | `Cache.GetActiveEngine()` fails (no-arg path) |
+| `Error: no active engine` | Active engine name is empty |
+| `Error: loading engines: <LoadManifests error>` | `engines.LoadManifests` fails — see [§4.1](#41-loadgo) |
+| `Error: machine info: <hardware_info.Get error>` | `hardware_info.Get` fails — see [§6.1](#61-hardware-infogo) |
+| `Error: scoring engines: <ScoreEngines error>` | `selector.ScoreEngines` fails — see [§5.1](#51-select_stackgo) |
+| `Error: engine "<name>" does not exist` | Named engine not found in scored list |
+| `Error: json: <json error>` | `json.MarshalIndent` fails |
+| `Error: yaml: <yaml error>` | `yaml.Marshal` fails |
+| `Error: unknown format "<value>"` | `--format` is not `"json"` or `"yaml"` |
+
+---
+
+### 2.4 `status.go`
+
+| Full stderr output | Condition |
+|---|---|
+| `Error: unknown format "<value>"` | `--format` is not `"json"` or `"yaml"` |
+| `Error: getting active engine: <snapctl error>` | `Cache.GetActiveEngine()` fails |
+| `Error: no engine is active` | Active engine name is empty |
+| `Error: getting services: <snapctl error>` | `snapctl.Services().Run()` fails |
+| `Error: unexpected service name format: "<name>"` | A service name has no `.` separator |
+| `Error: looking up active engine: <snapctl error>` | `Cache.GetActiveEngine()` inside `EngineComponentSettings` fails |
+| `Error: no active engine` | Active engine name empty inside `EngineComponentSettings` |
+| `Error: loading engine manifest: <OS/YAML error>` | Manifest load fails inside `EngineComponentSettings` |
+| `Error: SNAP_COMPONENTS env var not set` | `SNAP_COMPONENTS` not in environment |
+| `Error: reading <path>: <os error>` | `os.ReadFile` fails on a `component.yaml` |
+| `Error: unmarshaling <path>: <yaml error>` | `yaml.Unmarshal` fails on a `component.yaml` |
+| `Error: OPENAI_BASE_PATH env in component "<name>" is deprecated; set server settings in "servers".` | Deprecated env key found in component environment |
+| `Error: unsupported protocol "<proto>" for server "<server>" in component "<comp>"` | Protocol is not `"http"` or `"https"` |
+| `Error: getting "http.port": <snapctl error>` | `Config.Get("http.port")` fails |
+| `Error: yaml: <yaml error>` | `yaml.Marshal` of the status struct fails |
+| `Error: json: <json error>` | `json.MarshalIndent` of the status struct fails |
+
+---
+
+### 2.5 `chat.go`
+
+| Full stderr output | Condition |
+|---|---|
+| `Error: looking up active engine: <snapctl error>` | `Cache.GetActiveEngine()` inside `EngineComponentSettings` fails |
+| `Error: no active engine` | Active engine name empty inside `EngineComponentSettings` |
+| `Error: loading engine manifest: <OS/YAML error>` | Manifest load fails inside `EngineComponentSettings` |
+| `Error: SNAP_COMPONENTS env var not set` | `SNAP_COMPONENTS` not in environment |
+| `Error: reading <path>: <os error>` | `os.ReadFile` fails on a `component.yaml` |
+| `Error: unmarshaling <path>: <yaml error>` | `yaml.Unmarshal` fails on a `component.yaml` |
+| `Error: OPENAI_BASE_PATH env in component "<name>" is deprecated; set server settings in "servers".` | Deprecated env key |
+| `Error: unsupported protocol "<proto>" for server "<server>" in component "<comp>"` | Unsupported protocol |
+| `Error: getting "http.port": <snapctl error>` | `Config.Get("http.port")` fails |
+| `Error: "openai" not found in server endpoints` | No `openai` key in the endpoints map |
+| `Error: services: <snapctl error>` | `snapctl.Services(serviceName).Run()` fails |
+| `Error: server not active\n\n<suggestion string>` | The `.server` service `Current` state is `"inactive"` |
+| `Error: initializing readline: <error>` | `readline.NewEx` fails |
+| `Error: invalid base URL: <url.Parse error>` | `url.Parse(baseUrl)` fails in `handshake` |
+| `Error: connection refused\n\n<suggest-start>\n<suggest-logs>` | TCP dial to server is refused in `handshake` |
+| `Error: no models available on server\n\n<suggest-start>\n<suggest-logs>` | Server returns 503 `unavailable_error` for >60 s in `checkServerReady` |
+| `Error: api: <api error>` | Server returns a non-503 API error in `checkServerReady` or `lookupModelName` |
+| `Error: <other error>\n\n<suggest-logs>` | Any other error from `checkServerReady` or `lookupModelName` |
+| `Error: no models available on server\n\n<suggest-start>\n<suggest-logs>` | Server returns 503 `unavailable_error` for >60 s in `lookupModelName` |
+| `Error: server returned no models\n\n<suggest-start>\n<suggest-logs>` | Model list is empty for >60 s in `lookupModelName` |
+| `Error: server returned multiple models; expected one: <name1>, <name2>` | Server lists more than one model and `--model` not specified |
+| `Error: connection refused\n\n<suggest-logs>` | TCP connection refused mid-stream in `processStream` |
+| `Error: connection closed by server\n\n<suggest-logs>` | Unexpected EOF mid-stream in `processStream` |
+| `Error: <stream error>\n\n<suggest-logs>` | Any other streaming error in `processStream` |
+
+---
+
+### 2.6 `get.go`
+
+| Full stderr output | Condition |
+|---|---|
+| `Error: getting value of "<key>": <snapctl error>` | `Config.Get(key)` fails |
+| `Error: no value set for key "<key>"` | Key exists in schema but has no stored value |
+| `Error: serializing value: <yaml error>` | `yaml.Marshal` fails on the single-key result |
+| `Error: getting values: <snapctl error>` | `Config.GetAll()` fails |
+| `Error: serializing values: <yaml error>` | `yaml.Marshal` fails on the full config map |
+
+Non-fatal, printed directly to stderr:
+
+| Full stderr output | Condition |
+|---|---|
+| `Warning: "<key>" configuration field is deprecated!` | Requested key is in the deprecated-config list and output is a terminal |
+
+---
+
+### 2.7 `set.go`
+
+| Full stderr output | Condition |
+|---|---|
+| `Error: permission denied, try again with sudo` | Not root user |
+| `Error: key must not start with an equal sign` | First character of argument is `=` |
+| `Error: expected key=value, got "<arg>"` | No `=` in the argument |
+| `Error: "<key>" is read-only` | User tries to set a deprecated/internal config key |
+| `Error: setting "<key>" to "<value>": checking key: <snapctl error>` | `Config.Get(key)` fails during UserConfig key validation |
+| `Error: setting "<key>" to "<value>": unknown key` | Key has no existing value (not in schema) |
+| `Error: setting "<key>" to "<value>": <snapctl error>` | `storage.Set` (snapctl) fails |
+
+---
+
+### 2.8 `prune-cache.go`
+
+| Full stderr output | Condition |
+|---|---|
+| `Error: permission denied, try again with sudo` | Not root user |
+| `Error: <snapctl error>` | `Cache.GetActiveEngine()` fails (error returned unwrapped) |
+| `Error: no active engine found` | `engines.ErrManifestNotFound` for the active engine |
+| `Error: loading engine manifest: <OS/YAML error>` | Any other manifest load error for active engine |
+| `Error: cannot prune the active engine "<name>"` | `--engine` value matches the active engine |
+| `Error: "<name>" not found` | `engines.ErrManifestNotFound` for the named `--engine` |
+| `Error: loading engine manifest: <OS/YAML error>` | Other load error for named engine |
+| `Error: getting list of inactive engines: <LoadManifests or snapctl error>` | `engines.LoadManifests` or `Cache.GetActiveEngine` fails inside `inactiveEngines()` |
+| `Error: loading manifests: <LoadManifests error>` | `engines.LoadManifests` fails inside `getAllComponentsToRemove` or `pruneAllInactiveEngines` |
+| `Error: checking installed component directory "<comp>": <os error>` | `os.Stat` fails with non-not-exist error inside `calculateRemovableComponents` |
+| `Error: component "<comp>" exists but is not a directory` | Component path is a file inside `calculateRemovableComponents` |
+| `Error: un-setting engine configurations: <snapctl error>` | `Config.Unset(".", EngineConfig)` fails inside `pruneEngine` |
+| `Error: loading engine manifest: <OS/YAML error>` | Manifest load error inside `UnsetEngineConfig` |
+| `Error: un-setting configuration "<key>": <snapctl error>` | `Config.Unset(k, UserConfig)` fails |
+| `Error: removing components: <snapctl error>` | `snapctl.RemoveComponents` fails |
+
+Non-fatal, printed directly to **stdout** (no cobra prefix):
+
+| Full stdout output | Condition |
+|---|---|
+| `Warning: unable to get component sizes: <snap_store error>` | `snap_store.ComponentSizes()` fails **and** `--verbose` is set |
+| `Warning: unable to get component sizes` | `snap_store.ComponentSizes()` fails **and** `--verbose` is **not** set |
+
+---
+
+### 2.9 `run.go`
+
+| Full stderr output | Condition |
+|---|---|
+| `Error: unexpected number of arguments, expected 1 got <n>` | Not exactly 1 positional argument |
+| `Error: getting active engine: <snapctl error>` | `Cache.GetActiveEngine()` fails inside `waitForComponents` |
+| `Error: no active engine` | Active engine name is empty inside `waitForComponents` |
+| `Error: loading engine manifest: <OS/YAML error>` | Manifest load error inside `waitForComponents` |
+| `Error: SNAP_COMPONENTS env var not set` | `SNAP_COMPONENTS` not in environment inside `checkMissingComponents` |
+| `Error: <n>s timeout waiting for required components: <comp1>, <comp2>` | Components not mounted after 3600 s |
+| `Error: looking up active engine: <snapctl error>` | `Cache.GetActiveEngine()` inside `EngineComponentSettings` fails |
+| `Error: no active engine` | Active engine name empty inside `EngineComponentSettings` |
+| `Error: loading engine manifest: <OS/YAML error>` | Manifest load fails inside `EngineComponentSettings` |
+| `Error: SNAP_COMPONENTS env var not set` | `SNAP_COMPONENTS` not in environment inside `LoadEngineEnvironment` |
+| `Error: reading <path>: <os error>` | `os.ReadFile` fails on a `component.yaml` |
+| `Error: unmarshaling <path>: <yaml error>` | `yaml.Unmarshal` fails on `component.yaml` |
+| `Error: invalid env var "<entry>"` | An env entry in the component YAML has no `=` separator |
+| `Error: setting "COMPONENT": <os error>` | `os.Setenv(COMPONENT, ...)` fails |
+| `Error: unsetting "COMPONENT": <os error>` | `os.Unsetenv(COMPONENT)` fails |
+| `Error: setting "<key>": <os error>` | `os.Setenv(k, v)` fails for an engine env var |
+| `Error: <exec error>` | The subprocess exits non-zero (exec error returned directly) |
+
+---
+
+### 2.10 `show-machine.go`
+
+| Full stderr output | Condition |
+|---|---|
+| `Error: memory info: error reading /proc/meminfo: <os error>` | `/proc/meminfo` unreadable |
+| `Error: memory info: error parsing MemTotal: error parsing kB value: <strconv error>` | MemTotal kB parse fails |
+| `Error: memory info: error parsing MemTotal: error parsing byte value: <strconv error>` | MemTotal byte parse fails |
+| `Error: memory info: error parsing SwapTotal: error parsing kB value: <strconv error>` | SwapTotal kB parse fails |
+| `Error: memory info: error parsing SwapTotal: error parsing byte value: <strconv error>` | SwapTotal byte parse fails |
+| `Error: cpu info: reading /proc/cpuinfo: <os error>` | `/proc/cpuinfo` unreadable |
+| `Error: cpu info: getting host uname: <exec error>` | `uname --machine` binary missing or fails |
+| `Error: cpu info: unsupported architecture: <arch>` | `uname -m` output not in lookup table |
+| `Error: cpu info: unsupported architecture: <arch>` | Architecture from `/proc/cpuinfo` not `amd64`/`arm64` |
+| `Error: cpu info: <strconv error>` | Integer field parsing in `/proc/cpuinfo` fails |
+| `Error: disk info: statfs failed: <os error>` | `unix.Statfs` on the snap storage path fails |
+| `Error: pci devices: getting lspci data: <exec error>` | `lspci -vmmnD` fails |
+| `Error: pci devices: parsing lspci data: unexpected format for pci slot: <value>` | PCI slot field has wrong format |
+| `Error: pci devices: parsing lspci data: cannot parse pci bus number: <value>` | Bus-number hex parse fails |
+| `Error: json: <json error>` | `json.MarshalIndent` fails |
+| `Error: yaml: <yaml error>` | `yaml.Marshal` fails |
+| `Error: unknown format "<value>"` | `--format` is not `"json"` or `"yaml"` |
+
+---
+
+### 2.11 `version.go`
+
+| Full stderr output | Condition |
+|---|---|
+| `Error: json: <json error>` | `json.MarshalIndent` fails |
+| `Error: yaml: <yaml error>` | `yaml.Marshal` fails |
+| `Error: unknown format "<value>"` | `--format` is not `"json"` or `"yaml"` |
+
+---
+
+### 2.12 `debug/validate.go`
+
+| Full stderr output | Condition |
+|---|---|
+| `Error: no engine manifest specified` | Zero positional arguments |
+| `Error: not all manifests are valid` | At least one `engines.Validate` call returned an error |
+
+Per-file errors are printed **directly to stdout** (not returned, no cobra prefix):
+
+| Full stdout output | Condition |
+|---|---|
+| `❌ <path>: manifest file must be called engine.yaml: <path>` | File name doesn't end with `engine.yaml` |
+| `❌ <path>: manifest file does not exist: <path>` | `os.Stat` → ErrNotExist |
+| `❌ <path>: getting file info: <os error>` | `os.Stat` fails for any other reason |
+| `❌ <path>: reading file: <os error>` | `os.ReadFile` fails |
+| `❌ <path>: empty yaml data` | File is empty after trimming |
+| `❌ <path>: yaml: <yaml error>` | YAML parse error or unknown field |
+| `❌ <path>: required field is not set: name` | `name` field missing |
+| `❌ <path>: engine directory name should match name in manifest: <dir> != <name>` | Directory name ≠ manifest name |
+| `❌ <path>: required field is not set: description` | `description` field missing |
+| `❌ <path>: required field is not set: vendor` | `vendor` field missing |
+| `❌ <path>: required field is not set: grade` | `grade` field missing |
+| `❌ <path>: grade should be 'stable' or 'devel'` | `grade` is set but invalid |
+| `❌ <path>: parsing memory: <strconv error>` | `memory` value not a valid size string |
+| `❌ <path>: parsing disk space: <strconv error>` | `disk-space` value not a valid size string |
+| `❌ <path>: configuration field <key> is not a primitive value: <value>` | A configurations entry is non-primitive |
+| `❌ <path>: invalid device: allof <n>/<total>: cpu: architecture field required` | CPU device in `allof` missing `architecture` |
+| `❌ <path>: invalid device: allof <n>/<total>: cpu: invalid architecture: <value>` | Unknown architecture |
+| `❌ <path>: invalid device: allof <n>/<total>: cpu: invalid field for amd64: <field>` | Invalid field for amd64 CPU |
+| `❌ <path>: invalid device: allof <n>/<total>: cpu: invalid field for arm64: <field>` | Invalid field for arm64 CPU |
+| `❌ <path>: invalid device: allof <n>/<total>: gpu: invalid bus: <value>` | Unknown bus type for GPU |
+| `❌ <path>: invalid device: allof <n>/<total>: gpu: usb device validation not implemented` | GPU on USB bus |
+| `❌ <path>: invalid device: allof <n>/<total>: gpu: pci device: invalid field: <field>` | Invalid field for PCI GPU |
+| `❌ <path>: invalid device: allof <n>/<total>: npu: <bus/field error>` | NPU device errors (same bus/field patterns) |
+| `❌ <path>: invalid device: allof <n>/<total>: typeless: <bus/field error>` | Typeless device errors |
+| `❌ <path>: invalid device: allof <n>/<total>: invalid device type: <value>` | `type` not `cpu`, `gpu`, `npu`, or `""` |
+| *(same set with `anyof` instead of `allof`)* | Same errors for `anyof` devices |
+| `✅ <path>` | Manifest is valid |
+
+---
+
+### 2.13 `debug/select.go`
+
+| Full stderr output | Condition |
+|---|---|
+| `Error: decoding hardware info: <yaml error>` | `yaml.Decode` on stdin fails |
+| `Error: loading engines from directory: <LoadManifests error>` | `engines.LoadManifests` fails — see [§4.1](#41-loadgo) |
+| `Error: checking engines: parsing required memory: <strconv error>` | `utils.StringToBytes` fails for a manifest memory field |
+| `Error: checking engines: total memory not reported by host system` | `hardwareInfo.Memory.TotalRam == 0` |
+| `Error: checking engines: parsing required disk space: <strconv error>` | `utils.StringToBytes` fails for a manifest disk-space field |
+| `Error: checking engines: disk space not reported by host system` | Snap storage path not in disk info map |
+| `Error: finding top engine: no compatible engines found` | No stable compatible engine |
+| `Error: json: <json error>` | `json.MarshalIndent` fails |
+| `Error: yaml: <yaml error>` | `yaml.Marshal` fails |
+| `Error: unknown format "<value>"` | `--format` is not `"json"` or `"yaml"` |
+
+---
+
+### 2.14 `debug/chat.go`
+
+| Full stderr output | Condition |
+|---|---|
+| `Error: the --base-url parameter is required` | `--base-url` flag not provided |
+| `Error: initializing readline: <error>` | `readline.NewEx` fails |
+| `Error: invalid base URL: <url.Parse error>` | `url.Parse(baseUrl)` fails in `handshake` |
+| `Error: connection refused\n\n<suggest-start>\n<suggest-logs>` | TCP dial to server is refused |
+| `Error: no models available on server\n\n<suggest-start>\n<suggest-logs>` | Server 503 `unavailable_error` for >60 s in `checkServerReady` or `lookupModelName` |
+| `Error: api: <api error>` | Server returns a non-503 API error |
+| `Error: <other error>\n\n<suggest-logs>` | Any other error from `checkServerReady` or `lookupModelName` |
+| `Error: server returned no models\n\n<suggest-start>\n<suggest-logs>` | Model list empty for >60 s |
+| `Error: server returned multiple models; expected one: <name1>, <name2>` | Server lists >1 model and `--model` not specified |
+| `Error: connection refused\n\n<suggest-logs>` | TCP connection refused mid-stream |
+| `Error: connection closed by server\n\n<suggest-logs>` | Unexpected EOF mid-stream |
+| `Error: <stream error>\n\n<suggest-logs>` | Any other streaming error |
+
+---
+
+## 3. `cmd/cli/common/`
+
+### 3.1 `engine.go`
+
+These errors are propagated up through callers and ultimately reach cobra, which prefixes them with `Error: `.
+The tables below show the message fragment that each function contributes; callers add their own prefix before it.
+
+#### `EngineComponentSettings(ctx)` errors
+
+| Error message fragment | Condition |
+|---|---|
+| `looking up active engine: <snapctl error>` | `Cache.GetActiveEngine()` fails |
+| `no active engine` | Active engine name is empty |
+| `loading engine manifest: <OS/YAML error>` | Manifest load error — see [§4.1](#41-loadgo) |
+| `SNAP_COMPONENTS env var not set` | `SNAP_COMPONENTS` not in environment |
+| `reading <path>: <os error>` | `os.ReadFile` fails on a component's `component.yaml` |
+| `unmarshaling <path>: <yaml error>` | `yaml.Unmarshal` fails on `component.yaml` |
+
+#### `LoadEngineEnvironment(ctx)` errors
+
+| Error message fragment | Condition |
+|---|---|
+| *(all EngineComponentSettings errors above, propagated as-is)* | |
+| `SNAP_COMPONENTS env var not set` | Second check, inside the env-expansion loop |
+| `invalid env var "<entry>"` | Env entry in component YAML has no `=` |
+| `setting "COMPONENT": <os error>` | `os.Setenv(COMPONENT, ...)` fails |
+| `unsetting "COMPONENT": <os error>` | `os.Unsetenv(COMPONENT)` fails |
+| `setting "<key>": <os error>` | `os.Setenv(k, v)` fails |
+
+#### `SetEngineConfig(engine, ctx)` errors
+
+| Error message fragment | Condition |
+|---|---|
+| `setting engine configuration "<key>": <snapctl error>` | `Config.SetDocument` fails |
+
+#### `UnsetEngineConfig(engineName, unsetUserOverrides, ctx)` errors
+
+| Error message fragment | Condition |
+|---|---|
+| `un-setting engine configurations: <snapctl error>` | `Config.Unset(".", EngineConfig)` fails |
+| `loading engine manifest: <OS/YAML error>` | Manifest load error when `unsetUserOverrides=true` |
+| `un-setting configuration "<key>": <snapctl error>` | `Config.Unset(k, UserConfig)` fails |
+
+Non-fatal, printed directly to stderr (no cobra prefix):
+
+| Full stderr output | Condition |
+|---|---|
+| `Warning: previously active engine "<name>" not found; skipping user configuration cleanup.` | `engines.ErrManifestNotFound` when `unsetUserOverrides=true` |
+
+#### `ScoreEngines(ctx)` errors
+
+| Error message fragment | Condition |
+|---|---|
+| `loading engines: <LoadManifests error>` | `engines.LoadManifests` fails — see [§4.1](#41-loadgo) |
+| `machine info: <hardware_info.Get error>` | `hardware_info.Get(false)` fails — see [§6.1](#61-hardware-infogo) |
+| `scoring engines: <ScoreEngines error>` | `selector.ScoreEngines` fails — see [§5.1](#51-select_stackgo) |
+
+---
+
+### 3.2 `endpoints.go`
+
+#### `ServerEndpoints(ctx)` / `serverEndpoints()` / `serverHttpUrl()` errors
+
+| Error message fragment | Condition |
+|---|---|
+| *(all EngineComponentSettings errors, propagated as-is)* | `EngineComponentSettings` fails |
+| `OPENAI_BASE_PATH env in component "<name>" is deprecated; set server settings in "servers".` | Deprecated env key found |
+| `unsupported protocol "<proto>" for server "<server>" in component "<comp>"` | Protocol not `"http"` or `"https"` |
+| `getting "http.port": <snapctl error>` | `Config.Get("http.port")` fails |
+
+---
+
+### 3.3 `component.go`
+
+#### `ComponentInstalled(component)` errors
+
+| Error message fragment | Condition |
+|---|---|
+| `checking installed component directory "<comp>": <os error>` | `os.Stat` fails with non-ErrNotExist |
+| `component "<comp>" exists but is not a directory` | Path exists but is a regular file |
+
+---
+
+### 3.4 `errors.go`
+
+| Sentinel | Full value |
+|---|---|
+| `common.ErrPermissionDenied` | `permission denied, try again with sudo` |
+
+---
+
+## 4. `pkg/engines/`
+
+### 4.1 `load.go`
+
+#### `LoadManifests(manifestsDir)` errors
+
+| Error message fragment | Condition |
+|---|---|
+| `<manifestsDir>: <os error>` | `os.ReadDir(manifestsDir)` fails |
+| `<file path>: <os error>` | `os.ReadFile` fails on an engine YAML |
+| `<manifestsDir>: <yaml error>` | `yaml.Unmarshal` fails on an engine YAML |
+
+#### `LoadManifest(manifestsDir, engineName)` errors
+
+| Error message fragment | Condition |
+|---|---|
+| `engine manifest not found: <os ErrNotExist>` | File does not exist; wraps `ErrManifestNotFound` |
+| `<file path>: <os error>` | `os.ReadFile` fails for any other reason |
+| `<manifestsDir>: <yaml error>` | `yaml.Unmarshal` fails |
+
+---
+
+### 4.2 `validate.go`
+
+Errors from `Validate` are used by `debug/validate` (printed per-file, see [§2.12](#212-debugvalidatego)) and by `LoadManifest`; they are not surfaced directly by cobra.
+
+| Error message fragment | Condition |
+|---|---|
+| `manifest file must be called engine.yaml: <path>` | File name doesn't end with `engine.yaml` |
+| `manifest file does not exist: <path>` | `os.Stat` → ErrNotExist |
+| `getting file info: <os error>` | `os.Stat` fails for any other reason |
+| `reading file: <os error>` | `os.ReadFile` fails |
+| `empty yaml data` | File is empty after trimming |
+| `yaml: <yaml error>` | YAML parse error or unknown field |
+| `required field is not set: name` | `name` field missing |
+| `engine directory name should match name in manifest: <dir> != <name>` | Directory name ≠ manifest name |
+| `required field is not set: description` | `description` field missing |
+| `required field is not set: vendor` | `vendor` field missing |
+| `required field is not set: grade` | `grade` field missing |
+| `grade should be 'stable' or 'devel'` | `grade` is set but invalid |
+| `parsing memory: <strconv error>` | `memory` value is not a valid size string |
+| `parsing disk space: <strconv error>` | `disk-space` value is not a valid size string |
+| `configuration field <key> is not a primitive value: <value>` | A configurations entry is non-primitive |
+| `invalid device: allof <n>/<total>: <device error>` | A device in `allof` fails validation |
+| `invalid device: anyof <n>/<total>: <device error>` | A device in `anyof` fails validation |
+
+---
+
+### 4.3 `devices.go`
+
+| Error message fragment | Condition |
+|---|---|
+| `invalid device: allof <n>/<total>: <device error>` | A device in `allof` fails its own `validate()` |
+| `invalid device: anyof <n>/<total>: <device error>` | A device in `anyof` fails its own `validate()` |
+| `cpu: <cpu error>` | `validateCpu()` fails — see [§4.5](#45-cpugo) |
+| `gpu: <bus/field error>` | `validateGpu()` fails — see [§4.4](#44-bussesgo) |
+| `npu: <bus/field error>` | `validateNpu()` fails — see [§4.4](#44-bussesgo) |
+| `typeless: <bus/field error>` | `validateTypelessDevice()` fails — see [§4.4](#44-bussesgo) |
+| `invalid device type: <value>` | `type` field is not `cpu`, `gpu`, `npu`, or `""` |
+
+---
+
+### 4.4 `busses.go`
+
+| Error message fragment | Condition |
+|---|---|
+| `invalid bus: <value>` | `bus` field is not `"pci"`, `"usb"`, or `""` |
+| `usb device validation not implemented` | `bus == "usb"` |
+| `pci device: invalid field: <field>` | A non-zero struct field is not in the PCI allow-list |
+
+---
+
+### 4.5 `cpu.go`
+
+| Error message fragment | Condition |
+|---|---|
+| `architecture field required` | `device.Architecture == nil` |
+| `invalid architecture: <value>` | Architecture is set but not `"amd64"` or `"arm64"` |
+| `invalid field for amd64: <field>` | A non-zero struct field is not in the amd64 allow-list |
+| `invalid field for arm64: <field>` | A non-zero struct field is not in the arm64 allow-list |
+
+---
+
+## 5. `pkg/selector/`
+
+### 5.1 `select_stack.go`
+
+#### `TopEngine(scoredEngines)` — sentinel
+
+| Error message fragment | Condition |
+|---|---|
+| `no compatible engines found` | No engine with `Score > 0` and `Grade == "stable"` |
+
+#### `checkEngine(hardwareInfo, manifest)` — returned through `ScoreEngines`
+
+| Error message fragment | Condition |
+|---|---|
+| `parsing required memory: <strconv error>` | `utils.StringToBytes(*manifest.Memory)` fails |
+| `total memory not reported by host system` | `hardwareInfo.Memory.TotalRam == 0` |
+| `parsing required disk space: <strconv error>` | `utils.StringToBytes(*manifest.DiskSpace)` fails |
+| `disk space not reported by host system` | Snap storage path not in disk info map |
+
+*Device-level compatibility failures (wrong vendor, wrong type, etc.) are recorded as compatibility issues and reflected only in the score — they are never returned as errors.*
+
+---
+
+### 5.2 `pci/pci.go`
+
+`Match` never returns an `error`. Incompatibility reasons are returned as `[]string` device issues, which surface in `CompatibilityIssues` fields and verbose output:
+
+| Issue string | Condition |
+|---|---|
+| `no pci devices on host system` | `hostPciDevices` is empty |
+| `device not found` | No device survives vendor/device ID filtering |
+| `pci <slot>: vendor id mismatch: 0x<hex>` | Vendor ID doesn't match |
+| `pci <slot>: device id mismatch: 0x<hex>` | Device ID doesn't match |
+| `pci <slot>: device class 0x<hex> not of required type <type>` | Device class doesn't match required type |
+| `pci <slot>: <err from checkProperties>` | Property check failure — see [§5.3](#53-pcipropertiesgo) |
+| `pci <slot>: error checking snap connection "<conn>": <snapctl error>` | `snapctl.IsConnected` fails |
+| `pci <slot>: "<conn>" is not connected` | Required snap interface not connected |
+| `pci <slot>: no criteria met` | Device found but no scoring criterion matched |
+
+---
+
+### 5.3 `pci/properties.go`
+
+Errors returned from `checkProperties` become issue strings in `pci.go` (prefixed with `pci <slot>: `).
+
+| Error message fragment | Condition |
+|---|---|
+| `<strconv error>` | `utils.StringToBytes(*device.VRam)` fails — required vRAM is not a valid size string |
+| `error parsing vRAM: <strconv error>` | `utils.StringToBytes(vram)` fails on the device-reported vRAM value |
+| `not enough vRAM: <available bytes>` | Available vRAM < required |
+| `unable to detect vRAM` | `"vram"` key absent from `AdditionalProperties` |
+| `microarchitecture does not match: <actual>` | Microarch doesn't match required value |
+| `unable to detect microarchitecture` | `"microarchitecture"` key absent from `AdditionalProperties` |
+
+---
+
+## 6. `pkg/hardware_info/`
+
+### 6.1 `hardware-info.go`
+
+#### `Get(friendlyNames)` errors — propagated up (prefixed by callers)
+
+| Error message fragment | Condition |
+|---|---|
+| `memory info: <memory error>` | `memory.Info()` fails — see [§6.2](#62-memory) |
+| `cpu info: <cpu error>` | `cpu.Info()` fails — see [§6.3](#63-cpu) |
+| `disk info: <disk error>` | `disk.Info()` fails — see [§6.4](#64-disk) |
+| `pci devices: <pci error>` | `pci.Devices(friendlyNames)` fails — see [§6.5](#65-pcipci_devicesgo) |
+
+`show-machine` uses `fmt.Errorf("%s", err)` (bare, no extra prefix), so the above fragments appear directly after `Error: ` in the terminal. All other callers add their own prefix first (e.g. `machine info: ...` from `common/engine.go`).
+
+---
+
+### 6.2 `memory/`
+
+#### `memory.Info()` / `parseProcMemInfo()` errors
+
+| Error message fragment | Condition |
+|---|---|
+| `error reading /proc/meminfo: <os error>` | `os.ReadFile("/proc/meminfo")` fails |
+| `error parsing MemTotal: error parsing kB value: <strconv error>` | `strconv.ParseInt` on the kB part of MemTotal fails |
+| `error parsing MemTotal: error parsing byte value: <strconv error>` | `strconv.ParseInt` on a bare byte value of MemTotal fails |
+| `error parsing SwapTotal: error parsing kB value: <strconv error>` | Same for SwapTotal |
+| `error parsing SwapTotal: error parsing byte value: <strconv error>` | Same for SwapTotal |
+
+---
+
+### 6.3 `cpu/`
+
+#### `cpu.Info()` / `InfoFromRawData()` / `parseProcCpuInfo()` / `debianArchitecture()` errors
+
+| Error message fragment | Condition |
+|---|---|
+| `reading /proc/cpuinfo: <os error>` | `os.ReadFile("/proc/cpuinfo")` fails |
+| `getting host uname: <exec error>` | `exec.Command("uname", "--machine")` fails |
+| `unsupported architecture: <arch>` | `uname -m` output not in the debian-arch lookup table |
+| `unsupported architecture: <arch>` | Architecture string from `/proc/cpuinfo` not `"amd64"` or `"arm64"` |
+| `<strconv error>` | Parsing integer fields (processor index, implementer-id, part-number, variant, revision, cpu-khz) |
+
+---
+
+### 6.4 `disk/`
+
+#### `disk.Info()` / `disk.InfoFromRawData()` errors
+
+| Error message fragment | Condition |
+|---|---|
+| `statfs failed: <os error>` | `unix.Statfs(path, &fs)` fails |
+| `error parsing df: not 6 columns` | A `df` output line has wrong field count |
+| `error parsing df: error parsing 'total blocks' field: <strconv error>` | Total-blocks column parse fails |
+| `error parsing df: error parsing 'available blocks' field: <strconv error>` | Available-blocks column parse fails |
+| `df did not return info for all dirs` | Fewer parsed entries than expected directories |
+
+---
+
+### 6.5 `pci/pci_devices.go`
+
+#### `pci.Devices(friendlyNames)` errors
+
+| Error message fragment | Condition |
+|---|---|
+| `getting lspci data: <exec error>` | `exec.Command("lspci", "-vmmnD").Output()` fails |
+| `parsing lspci data: unexpected format for pci slot: <value>` | PCI slot has wrong format |
+| `parsing lspci data: cannot parse pci bus number: <value>` | Bus-number hex parse fails |
+
+Additional-properties errors are non-fatal, printed directly to stderr (no cobra prefix):
+
+| Full stderr output | Condition |
+|---|---|
+| `Warning: failed to get additional properties: AMD: vRAM: <os error>` | AMD `/sys/bus/pci/devices/<slot>/mem_info_vram_total` unreadable |
+| `Warning: failed to get additional properties: AMD: vRAM: <strconv error>` | AMD vRAM file content not a valid integer |
+| `Warning: failed to get additional properties: AMD: gfx architecture: <os error>` | `/sys/class/kfd/kfd/topology/nodes` unreadable |
+| `Warning: failed to get additional properties: AMD: gfx architecture: gfx_target_version not found for device with pci slot <slot>` | No KFD node matched the device |
+| `Warning: failed to get additional properties: AMD: gfx architecture: gfx_target_version is invalid for this device` | Value is `"0"` |
+| `Warning: failed to get additional properties: AMD: gfx architecture: gfx_target_version has an unexpected format: <value>` | Hex string shorter than 6 chars |
+| `Warning: failed to get additional properties: AMD: gfx architecture: parsing major version from gfx_target_version: <strconv error>` | `strconv.Atoi` fails on chars 0–1 |
+| `Warning: failed to get additional properties: AMD: gfx architecture: parsing minor version from gfx_target_version: <strconv error>` | `strconv.Atoi` fails on chars 2–3 |
+| `Warning: failed to get additional properties: AMD: gfx architecture: parsing revision from gfx_target_version: <strconv error>` | `strconv.Atoi` fails on chars 4–5 |
+| `Warning: failed to get additional properties: AMD: gfx architecture: unexpected format for gfx_target_version: <line>` | Line not 2 space-separated parts |
+| `Warning: failed to get additional properties: NVIDIA: vRAM: nvidia-smi: <exec error>` | `nvidia-smi` fails, no stdout output |
+| `Warning: failed to get additional properties: NVIDIA: vRAM: nvidia-smi: <exec error>: <stdout>` | `nvidia-smi` fails with stdout error message |
+| `Warning: failed to get additional properties: NVIDIA: vRAM: <strconv error>` | vRAM value string not a valid integer |
+| `Warning: failed to get additional properties: NVIDIA: compute capability: nvidia-smi: <exec error>` | Same patterns for compute-capability query |
+| `Warning: failed to get additional properties: NVIDIA: compute capability: nvidia-smi: <exec error>: <stdout>` | Same |
+| `Warning: failed to get additional properties: Intel: vRAM: <exec error>` | `clinfo --json` fails |
+| `Warning: failed to get additional properties: Intel: vRAM: parsing clinfo json: <json error>` | JSON parse of clinfo output fails |
+| `Warning: failed to get additional properties: Intel: vRAM: clinfo: no devices found` | `clinfo.Devices` is empty |
+| `Warning: failed to get additional properties: Intel: vRAM: clinfo: no online devices found` | `clinfo.Devices[0].Online` is empty |
+
+---
+
+### 6.6 `pci/lspci.go`
+
+#### `ParseLsPci()` errors
+
+| Error message fragment | Condition |
+|---|---|
+| `unexpected format for pci slot: <value>` | Slot field not two `:` separators |
+| `cannot parse pci bus number: <value>` | Bus-number hex string can't be parsed |
+
+Friendly-name lookup failures are non-fatal, printed directly to stderr:
+
+| Full stderr output | Condition |
+|---|---|
+| `Error looking up friendly name: opening pci database: <pcidb error>` | `pcidb.New()` fails |
+
+---
+
+### 6.7 `pci/nvidia/`
+
+All nvidia errors surface as `Warning: failed to get additional properties: NVIDIA: ...` via [§6.5](#65-pcipci_devicesgo).
+
+| Error chain (after `NVIDIA: `) | Condition |
+|---|---|
+| `vRAM: nvidia-smi: <exec error>` | `nvidia-smi` not found / fails, no stdout output |
+| `vRAM: nvidia-smi: <exec error>: <stdout>` | `nvidia-smi` fails with stdout error message |
+| `vRAM: <strconv error>` | vRAM value string not a valid integer |
+| `compute capability: nvidia-smi: <exec error>` | Same patterns for compute-capability query |
+| `compute capability: nvidia-smi: <exec error>: <stdout>` | Same |
+
+---
+
+### 6.8 `pci/amd/`
+
+All AMD errors surface as `Warning: failed to get additional properties: AMD: ...` via [§6.5](#65-pcipci_devicesgo).
+
+| Error chain (after `AMD: `) | Condition |
+|---|---|
+| `vRAM: <os error>` | `/sys/bus/pci/devices/<slot>/mem_info_vram_total` unreadable |
+| `vRAM: <strconv error>` | File content not a valid integer |
+| `gfx architecture: <os error>` | `/sys/class/kfd/kfd/topology/nodes` unreadable |
+| `gfx architecture: gfx_target_version not found for device with pci slot <slot>` | No KFD node matched the device |
+| `gfx architecture: gfx_target_version is invalid for this device` | Value is `"0"` |
+| `gfx architecture: gfx_target_version has an unexpected format: <value>` | Hex string shorter than 6 chars |
+| `gfx architecture: parsing major version from gfx_target_version: <strconv error>` | `strconv.Atoi` fails on chars 0–1 |
+| `gfx architecture: parsing minor version from gfx_target_version: <strconv error>` | `strconv.Atoi` fails on chars 2–3 |
+| `gfx architecture: parsing revision from gfx_target_version: <strconv error>` | `strconv.Atoi` fails on chars 4–5 |
+| `gfx architecture: unexpected format for gfx_target_version: <line>` | Line not 2 space-separated parts |
+
+---
+
+### 6.9 `pci/intel/`
+
+All Intel errors surface as `Warning: failed to get additional properties: Intel: ...` via [§6.5](#65-pcipci_devicesgo).
+
+| Error chain (after `Intel: `) | Condition |
+|---|---|
+| `vRAM: <exec error>` | `clinfo --json` binary missing or command fails |
+| `vRAM: parsing clinfo json: <json error>` | `json.Unmarshal` on clinfo output fails |
+| `vRAM: clinfo: no devices found` | `clinfo.Devices` is empty |
+| `vRAM: clinfo: no online devices found` | `clinfo.Devices[0].Online` is empty |
+
+*(When vRAM lookup succeeds but no device PCI address matches `device.Slot`, `nil` is returned without error.)*
+
+---
+
+## 7. `pkg/snap_store/snap_store.go`
+
+All errors from this package surface as one of:
+- `Warning: unable to get component sizes: components sizes: <error>` — `use-engine` with `--verbose` (to stderr)
+- `Warning: unable to get component sizes` — `use-engine` without `--verbose`, error detail suppressed (to stderr)
+- `Warning: unable to get component sizes: <error>` — `prune-cache` with `--verbose`, wraps one level less (to stdout)
+- `Warning: unable to get component sizes` — `prune-cache` without `--verbose` (to stdout)
+
+Full error chains from `ComponentSizes()`:
+
+| Full error chain from `ComponentSizes` | Condition |
+|---|---|
+| `components sizes: SNAP_NAME is not set. Likely not inside a snap` | `$SNAP_NAME` env-var is empty |
+| `components sizes: SNAP_REVISION is not set` | `$SNAP_REVISION` env-var is empty |
+| `components sizes: not installed from store` | Revision starts with `"x"` (sideloaded) |
+| `components sizes: parsing snap revision: <strconv error>` | `strconv.ParseInt` on revision string fails |
+| `components sizes: getting snap info: creating new http request: <net error>` | `http.NewRequest` for snap info fails |
+| `components sizes: getting snap info: HTTP request: <net error>` | Network error fetching snap info |
+| `components sizes: getting snap info: HTTP status not OK: <code>` | Snap info response not 200 |
+| `components sizes: getting snap info: json: <json error>` | JSON decode of snap info response fails |
+| `components sizes: getting components: fetching refresh data from store: json: <json error>` | `json.Marshal` of refresh request body fails |
+| `components sizes: getting components: fetching refresh data from store: new http request: <net error>` | `http.NewRequest` for refresh fails |
+| `components sizes: getting components: fetching refresh data from store: HTTP request: <net error>` | Network error on refresh call |
+| `components sizes: getting components: fetching refresh data from store: HTTP status not OK: <code>` | Refresh response not 200 |
+| `components sizes: getting components: fetching refresh data from store: json: <json error>` | JSON decode of refresh response fails |
+| `components sizes: getting components: store returned no refresh results` | `Results` slice is empty |
+| `components sizes: getting components: no refresh results found for snap id <id>` | No result matches the snap ID |
+
+---
+
+## 8. `pkg/storage/`
+
+### 8.1 `cache.go`
+
+#### `SetActiveEngine(engine)` errors
+
+| Error message fragment | Condition |
+|---|---|
+| `engine name cannot be empty` | `engine == ""` |
+| `<snapctl.Set error>` | External snapctl error (unwrapped) |
+
+#### `GetActiveEngine()` errors
+
+| Error message fragment | Condition |
+|---|---|
+| `<snapctl.Get or json.Unmarshal error>` | Any non-ErrorNotFound storage error (unwrapped) |
+
+---
+
+### 8.2 `config.go`
+
+#### `Config.Set(key, value, confType)` errors
+
+| Error message fragment | Condition |
+|---|---|
+| `checking key: <snapctl error>` | `Config.Get(key)` fails during UserConfig validation |
+| `unknown key` | Key not in schema (no existing value) |
+| `<snapctl.Set error>` | `storage.Set` fails (unwrapped) |
+
+#### `Config.SetDocument(key, value, confType)` errors
+
+| Error message fragment | Condition |
+|---|---|
+| `<json.Marshal error>` | Value cannot be marshalled (unwrapped) |
+| `<snapctl.Set error>` | `snapctl.Set(...).Document().Run()` fails (unwrapped) |
+
+#### `Config.Get(key)` / `Config.GetAll()` errors
+
+| Error message fragment | Condition |
+|---|---|
+| `<snapctl.Get or json.Unmarshal error>` | `loadConfigs` → `storage.Get` fails (unwrapped) |
+
+#### `Config.Unset(key, confType)` errors
+
+| Error message fragment | Condition |
+|---|---|
+| `<snapctl.Unset error>` | `snapctl.Unset(...).Run()` fails (unwrapped) |
+
+---
+
+### 8.3 `snapctl_storage.go`
+
+The external boundary. All errors are raw errors from `github.com/canonical/go-snapctl` or stdlib:
+
+| Method | External error source |
+|---|---|
+| `Set` | `snapctl.Set(...).Run()` |
+| `SetDocument` | `json.Marshal` (stdlib) or `snapctl.Set(...).Document().Run()` |
+| `Get` | `snapctl.Get(...).Run()` or `json.Unmarshal` (stdlib) |
+| `Unset` | `snapctl.Unset(...).Run()` |
+
+`ErrorNotFound` (`"not found"`) is returned (and immediately handled in `cache.go`) when `snapctl.Get` returns an empty string.
+
+---
+
+## 9. `pkg/utils/utils.go`
+
+#### `StringToBytes(sizeString)` errors
+
+| Error message fragment | Condition |
+|---|---|
+| `<strconv.ParseUint error>` | Numeric part of the size string is not a valid integer (unwrapped) |
+
+#### `SubDirectories(dirPath)` errors
+
+| Error message fragment | Condition |
+|---|---|
+| `failed to read directory: <os error>` | `os.ReadDir(dirPath)` fails |
+
+---
+
+## Cross-cutting Notes
+
+### Non-fatal outputs (never cobra-prefixed, never returned as errors)
+
+| Full output | Stream | Source | Condition |
+|---|---|---|---|
+| `Warning: unable to get component sizes: <error>` | stderr | `use-engine.go` | `snap_store.ComponentSizes()` fails with `--verbose` |
+| `Warning: unable to get component sizes` | stderr | `use-engine.go` | Same, without `--verbose` |
+| `Warning: unable to get component sizes: <error>` | stdout | `prune-cache.go` | `snap_store.ComponentSizes()` fails with `--verbose` |
+| `Warning: unable to get component sizes` | stdout | `prune-cache.go` | Same, without `--verbose` |
+| `Warning: previously active engine "<name>" not found; skipping user configuration cleanup.` | stderr | `engine.go` | `ErrManifestNotFound` during unset with `unsetUserOverrides=true` |
+| `Warning: failed to get additional properties: <vendor>: <error>` | stderr | `pci_devices.go` | Per-device, non-fatal; all AMD/NVIDIA/Intel tool errors |
+| `Error looking up friendly name: <error>` | stderr | `lspci.go` | Per-device, non-fatal PCI database lookup failure |
+| `No engines found.` | stderr | `list-engines.go` | Engine list is empty |
+| `Warning: "<key>" configuration field is deprecated!` | stderr | `get.go` | Deprecated key requested on a terminal |
+
+### Sentinel errors (used with `errors.Is`)
+
+| Sentinel | Package | Checked in |
+|---|---|---|
+| `engines.ErrManifestNotFound` | `pkg/engines` | `use-engine`, `prune-cache`, `run`, `engine.go` (`UnsetEngineConfig`) |
+| `selector.ErrorNoCompatibleEngine` | `pkg/selector` | `use-engine` (`autoSelectEngine`), `debug/select` |
+| `storage.ErrorNotFound` | `pkg/storage` | `cache.go` (`GetActiveEngine`) — handled internally, never surfaces to the user |
+| `pci.ErrorVendorNotSupported` | `pkg/hardware_info/pci` | `pci_devices.go` (`addAdditionalProperties`) — silently ignored |
+
+### Root-only commands (return `Error: permission denied, try again with sudo` immediately if not root)
+
+`use-engine`, `set`, `prune-cache`

--- a/pkg/engines/cpu.go
+++ b/pkg/engines/cpu.go
@@ -40,7 +40,7 @@ func (device Device) validateAmd64() error {
 		fieldValue := v.FieldByName(fieldName)
 		if fieldValue.IsValid() && !fieldValue.IsZero() {
 			if !slices.Contains(validFields, fieldName) {
-				return fmt.Errorf("cpu amd64: invalid field: %s", fieldName)
+				return fmt.Errorf("invalid field for amd64: %s", fieldName)
 			}
 		}
 	}
@@ -66,7 +66,7 @@ func (device Device) validateArm64() error {
 		fieldValue := v.FieldByName(fieldName)
 		if fieldValue.IsValid() && !fieldValue.IsZero() {
 			if !slices.Contains(validFields, fieldName) {
-				return fmt.Errorf("cpu arm64: invalid field: %s", fieldName)
+				return fmt.Errorf("invalid field for arm64: %s", fieldName)
 			}
 		}
 	}

--- a/pkg/engines/devices.go
+++ b/pkg/engines/devices.go
@@ -59,7 +59,7 @@ func (device Device) validateGpu() error {
 
 	err := device.validateBus(extraFields)
 	if err != nil {
-		return fmt.Errorf("gpu: %v", err)
+		return fmt.Errorf("%v", err)
 	}
 	return nil
 }
@@ -67,7 +67,7 @@ func (device Device) validateGpu() error {
 func (device Device) validateNpu() error {
 	err := device.validateBus(nil)
 	if err != nil {
-		return fmt.Errorf("npu: %v", err)
+		return fmt.Errorf("%v", err)
 	}
 	return nil
 }
@@ -75,7 +75,7 @@ func (device Device) validateNpu() error {
 func (device Device) validateTypelessDevice() error {
 	err := device.validateBus(nil)
 	if err != nil {
-		return fmt.Errorf("typeless device: %v", err)
+		return fmt.Errorf("%v", err)
 	}
 	return nil
 }

--- a/pkg/engines/validate.go
+++ b/pkg/engines/validate.go
@@ -22,12 +22,12 @@ func Validate(manifestFilePath string) error {
 		if errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("manifest file does not exist: %s", manifestFilePath)
 		}
-		return fmt.Errorf("error getting file info: %v", err)
+		return fmt.Errorf("getting file info: %v", err)
 	}
 
 	yamlData, err := os.ReadFile(manifestFilePath)
 	if err != nil {
-		return fmt.Errorf("error reading file: %v", err)
+		return fmt.Errorf("reading file: %v", err)
 	}
 
 	// Get engine name from path
@@ -59,7 +59,7 @@ func validateManifestYaml(expectedName string, yamlData []byte) error {
 
 	// We depend on the yaml unmarshal to check field types
 	if err := yamlDecoder.Decode(&manifest); err != nil {
-		return fmt.Errorf("error decoding: %v", err)
+		return fmt.Errorf("yaml: %v", err)
 	}
 
 	return manifest.validate(expectedName)
@@ -95,14 +95,14 @@ func (manifest Manifest) validate(expectedEngineName string) error {
 	if manifest.Memory != nil {
 		_, err := utils.StringToBytes(*manifest.Memory)
 		if err != nil {
-			return fmt.Errorf("error parsing memory: %v", err)
+			return fmt.Errorf("parsing memory: %v", err)
 		}
 	}
 
 	if manifest.DiskSpace != nil {
 		_, err := utils.StringToBytes(*manifest.DiskSpace)
 		if err != nil {
-			return fmt.Errorf("error parsing disk space: %v", err)
+			return fmt.Errorf("parsing disk space: %v", err)
 		}
 	}
 

--- a/pkg/hardware_info/cpu/cpu.go
+++ b/pkg/hardware_info/cpu/cpu.go
@@ -12,17 +12,17 @@ import (
 func Info() ([]types.CpuInfo, error) {
 	hostProcCpu, err := hostProcCpuInfo()
 	if err != nil {
-		return nil, fmt.Errorf("failed to look up host /proc/cpuinfo: %v", err)
+		return nil, fmt.Errorf("%v", err)
 	}
 
 	hostUname, err := hostUnameMachine()
 	if err != nil {
-		return []types.CpuInfo{}, fmt.Errorf("error getting host uname: %v", err)
+		return []types.CpuInfo{}, fmt.Errorf("uname: %v", err)
 	}
 
 	cpus, err := InfoFromRawData(hostProcCpu, hostUname)
 	if err != nil {
-		return []types.CpuInfo{}, fmt.Errorf("error parsing cpu data: %v", err)
+		return []types.CpuInfo{}, fmt.Errorf("%v", err)
 	}
 
 	return cpus, nil
@@ -33,12 +33,12 @@ func InfoFromRawData(procCpuInfoData string, uname string) ([]types.CpuInfo, err
 
 	machineProcCpuInfo, err := parseProcCpuInfo(procCpuInfoData, architecture)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing /proc/cpuinfo: %v", err)
+		return nil, fmt.Errorf("%v", err)
 	}
 
 	cpus, err := uniqueCpuInfo(machineProcCpuInfo)
 	if err != nil {
-		return nil, fmt.Errorf("error filtering cpu info: %v", err)
+		return nil, fmt.Errorf("%v", err)
 	}
 
 	return cpus, nil
@@ -54,7 +54,7 @@ func uniqueCpuInfo(procCpus []ProcCpuInfo) ([]types.CpuInfo, error) {
 
 	cpuInfos, err := cpuInfoFromProc(procCpus)
 	if err != nil {
-		return nil, fmt.Errorf("error converting cpu info: %v", err)
+		return nil, fmt.Errorf("%v", err)
 	}
 	return cpuInfos, nil
 }

--- a/pkg/hardware_info/cpu/proc_cpuinfo.go
+++ b/pkg/hardware_info/cpu/proc_cpuinfo.go
@@ -13,7 +13,7 @@ func hostProcCpuInfo() (string, error) {
 	// cat /proc/cpuinfo
 	cpuInfoBytes, err := os.ReadFile("/proc/cpuinfo")
 	if err != nil {
-		return "", fmt.Errorf("error reading /proc/cpuinfo: %v", err)
+		return "", fmt.Errorf("reading /proc/cpuinfo: %v", err)
 	}
 	return string(cpuInfoBytes), nil
 }
@@ -25,7 +25,7 @@ func parseProcCpuInfo(cpuInfoString string, architecture string) ([]ProcCpuInfo,
 	case constants.Arm64:
 		return parseProcCpuInfoArm64(cpuInfoString)
 	default:
-		return nil, fmt.Errorf("can't parse /proc/cpuinfo. unsupported architecture: %s", architecture)
+		return nil, fmt.Errorf("unsupported architecture: %s", architecture)
 	}
 }
 

--- a/pkg/hardware_info/disk/disk_df.go
+++ b/pkg/hardware_info/disk/disk_df.go
@@ -45,12 +45,12 @@ func parseDf(dfData string) ([]types.DirStats, error) {
 
 		totalSize, err := strconv.ParseUint(fields[1], 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing 'total blocks' field: %v", err)
+			return nil, fmt.Errorf("'total blocks' field: %v", err)
 		}
 		//usedSize, err := strconv.ParseUint(fields[2], 10, 64)
 		availableSize, err := strconv.ParseUint(fields[3], 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing 'available blocks' field: %v", err)
+			return nil, fmt.Errorf("'available blocks' field: %v", err)
 		}
 
 		var thisDir = types.DirStats{

--- a/pkg/hardware_info/disk/disk_info.go
+++ b/pkg/hardware_info/disk/disk_info.go
@@ -18,7 +18,7 @@ func Info() (map[string]types.DirStats, error) {
 	for _, dir := range directories {
 		dirInfo, err := statFs(dir)
 		if err != nil {
-			return nil, fmt.Errorf("error getting directory info: %v", err)
+			return nil, fmt.Errorf("%v", err)
 		}
 		info[dir] = dirInfo
 	}

--- a/pkg/hardware_info/hardware-info.go
+++ b/pkg/hardware_info/hardware-info.go
@@ -18,25 +18,25 @@ func Get(friendlyNames bool) (*types.HwInfo, error) {
 
 	memoryInfo, err := memory.Info()
 	if err != nil {
-		return nil, fmt.Errorf("error getting memory info: %v", err)
+		return nil, fmt.Errorf("memory info: %v", err)
 	}
 	hwInfo.Memory = memoryInfo
 
 	cpus, err := cpu.Info()
 	if err != nil {
-		return nil, fmt.Errorf("error getting cpu info: %v", err)
+		return nil, fmt.Errorf("cpu info: %v", err)
 	}
 	hwInfo.Cpus = cpus
 
 	diskInfo, err := disk.Info()
 	if err != nil {
-		return nil, fmt.Errorf("error getting disk info: %v", err)
+		return nil, fmt.Errorf("disk info: %v", err)
 	}
 	hwInfo.Disk = diskInfo
 
 	pciDevices, err := pci.Devices(friendlyNames)
 	if err != nil {
-		return nil, fmt.Errorf("error getting pci devices: %v", err)
+		return nil, fmt.Errorf("pci devices: %v", err)
 	}
 	hwInfo.PciDevices = pciDevices
 

--- a/pkg/hardware_info/memory/memory_info.go
+++ b/pkg/hardware_info/memory/memory_info.go
@@ -9,7 +9,7 @@ import (
 func Info() (types.MemoryInfo, error) {
 	hostProcMemInfoData, err := hostProcMemInfo()
 	if err != nil {
-		return types.MemoryInfo{}, fmt.Errorf("failed to look up host /proc/meminfo: %v", err)
+		return types.MemoryInfo{}, fmt.Errorf("%v", err)
 	}
 	return InfoFromRawData(hostProcMemInfoData)
 }
@@ -17,7 +17,7 @@ func Info() (types.MemoryInfo, error) {
 func InfoFromRawData(procMemInfoData string) (types.MemoryInfo, error) {
 	machineMemInfo, err := parseProcMemInfo(procMemInfoData)
 	if err != nil {
-		return types.MemoryInfo{}, fmt.Errorf("failed to parse /proc/meminfo data: %v", err)
+		return types.MemoryInfo{}, fmt.Errorf("%v", err)
 	}
 	return machineMemInfo, nil
 }

--- a/pkg/hardware_info/memory/proc_meminfo.go
+++ b/pkg/hardware_info/memory/proc_meminfo.go
@@ -13,7 +13,7 @@ func hostProcMemInfo() (string, error) {
 	// cat /proc/meminfo
 	memInfoBytes, err := os.ReadFile("/proc/meminfo")
 	if err != nil {
-		return "", fmt.Errorf("error reading /proc/meminfo: %v", err)
+		return "", fmt.Errorf("reading /proc/meminfo: %v", err)
 	}
 	return string(memInfoBytes), nil
 }
@@ -41,13 +41,13 @@ func parseProcMemInfo(memInfoString string) (types.MemoryInfo, error) {
 		case "MemTotal":
 			valueBytes, err := procStringToBytes(value)
 			if err != nil {
-				return memInfo, fmt.Errorf("error parsing MemTotal: %v", err)
+				return memInfo, fmt.Errorf("MemTotal: %v", err)
 			}
 			memInfo.TotalRam = uint64(valueBytes)
 		case "SwapTotal":
 			valueBytes, err := procStringToBytes(value)
 			if err != nil {
-				return memInfo, fmt.Errorf("error parsing SwapTotal: %v", err)
+				return memInfo, fmt.Errorf("SwapTotal: %v", err)
 			}
 			memInfo.TotalSwap = uint64(valueBytes)
 		}
@@ -63,13 +63,13 @@ func procStringToBytes(s string) (int64, error) {
 		s = strings.TrimSpace(s)
 		kbValue, err := strconv.ParseInt(s, 10, 64)
 		if err != nil {
-			return 0, fmt.Errorf("error parsing kB value: %v", err)
+			return 0, fmt.Errorf("parsing kB value: %v", err)
 		}
 		return kbValue * 1024, nil
 	} else {
 		bValue, err := strconv.ParseInt(s, 10, 64)
 		if err != nil {
-			return 0, fmt.Errorf("error parsing byte value: %v", err)
+			return 0, fmt.Errorf("parsing byte value: %v", err)
 		}
 		return bValue, nil
 	}

--- a/pkg/hardware_info/pci/amd/amd.go
+++ b/pkg/hardware_info/pci/amd/amd.go
@@ -20,7 +20,7 @@ func AdditionalProperties(pciDevice types.PciDevice) (map[string]string, error) 
 	if pciDevice.DeviceClass == 0x0001 || pciDevice.DeviceClass&0xFF00 == 0x0300 {
 		properties, err = gpuProperties(pciDevice)
 		if err != nil {
-			return nil, fmt.Errorf("error getting gpu properties: %v", err)
+			return nil, fmt.Errorf("%v", err)
 		}
 	}
 

--- a/pkg/hardware_info/pci/amd/gpu.go
+++ b/pkg/hardware_info/pci/amd/gpu.go
@@ -19,14 +19,14 @@ func gpuPropertiesFromDir(pciDevice types.PciDevice, rootDir string) (map[string
 
 	vRamVal, err := vRam(pciDevice, rootDir)
 	if err != nil {
-		return nil, fmt.Errorf("error looking up vRAM: %v", err)
+		return nil, fmt.Errorf("vRAM: %v", err)
 	}
 	if vRamVal != nil {
 		properties["vram"] = strconv.FormatUint(*vRamVal, 10)
 	}
 	gfxArchitecture, err := gfxArchitecture(pciDevice, rootDir)
 	if err != nil {
-		return nil, fmt.Errorf("error looking up gfx architecture: %v", err)
+		return nil, fmt.Errorf("gfx architecture: %v", err)
 	}
 	if len(gfxArchitecture) > 0 {
 		properties["microarchitecture"] = gfxArchitecture
@@ -137,19 +137,19 @@ func parseGfxTargetVersion(gfxTargetVersionLine string) (string, error) {
 
 		majorInt, err := strconv.Atoi(deviceLower[0:2])
 		if err != nil {
-			return "", fmt.Errorf("error parsing major version from gfx_target_version: %v", err)
+			return "", fmt.Errorf("parsing major version from gfx_target_version: %v", err)
 		}
 		major := strconv.Itoa(majorInt)
 
 		minorInt, err := strconv.Atoi(deviceLower[2:4])
 		if err != nil {
-			return "", fmt.Errorf("error parsing minor version from gfx_target_version: %v", err)
+			return "", fmt.Errorf("parsing minor version from gfx_target_version: %v", err)
 		}
 		minor := strconv.Itoa(minorInt)
 
 		revisionInt, err := strconv.Atoi(deviceLower[4:6])
 		if err != nil {
-			return "", fmt.Errorf("error parsing revision from gfx_target_version: %v", err)
+			return "", fmt.Errorf("parsing revision from gfx_target_version: %v", err)
 		}
 		revision := strconv.Itoa(revisionInt)
 

--- a/pkg/hardware_info/pci/amd/gpu_test.go
+++ b/pkg/hardware_info/pci/amd/gpu_test.go
@@ -180,19 +180,19 @@ func TestGetGfxTargetVersion(t *testing.T) {
 		{
 			name:          "unexpected major format non numeric",
 			input:         "gfx_target_version ab1234",
-			errContains:   "error parsing major version from gfx_target_version",
+			errContains:   "invalid syntax",
 			expectFailure: true,
 		},
 		{
 			name:          "unexpected minor format non numeric",
 			input:         "gfx_target_version 12ab34",
-			errContains:   "error parsing minor version from gfx_target_version",
+			errContains:   "invalid syntax",
 			expectFailure: true,
 		},
 		{
 			name:          "unexpected revision format non numeric",
 			input:         "gfx_target_version 1234ab",
-			errContains:   "error parsing revision from gfx_target_version",
+			errContains:   "invalid syntax",
 			expectFailure: true,
 		},
 		{

--- a/pkg/hardware_info/pci/intel/gpu.go
+++ b/pkg/hardware_info/pci/intel/gpu.go
@@ -20,7 +20,7 @@ func gpuProperties(pciDevice types.PciDevice) (map[string]string, error) {
 
 	vRamVal, err := vRam(pciDevice)
 	if err != nil {
-		return nil, fmt.Errorf("error looking up vRAM: %v", err)
+		return nil, fmt.Errorf("vRAM: %v", err)
 	}
 	if vRamVal != nil {
 		properties["vram"] = strconv.FormatUint(*vRamVal, 10)
@@ -54,7 +54,7 @@ func vRam(device types.PciDevice) (*uint64, error) {
 
 	clinfo, err := parseClinfoJson(data)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse clinfo json: %w", err)
+		return nil, fmt.Errorf("parsing clinfo json: %w", err)
 	}
 	if len(clinfo.Devices) == 0 {
 		return nil, fmt.Errorf("clinfo: no devices found")

--- a/pkg/hardware_info/pci/intel/intel.go
+++ b/pkg/hardware_info/pci/intel/intel.go
@@ -20,7 +20,7 @@ func AdditionalProperties(pciDevice types.PciDevice) (map[string]string, error) 
 	if pciDevice.DeviceClass == 0x0001 || pciDevice.DeviceClass&0xFF00 == 0x0300 {
 		properties, err = gpuProperties(pciDevice)
 		if err != nil {
-			return nil, fmt.Errorf("error getting gpu properties: %v", err)
+			return nil, fmt.Errorf("%v", err)
 		}
 	}
 

--- a/pkg/hardware_info/pci/lspci.go
+++ b/pkg/hardware_info/pci/lspci.go
@@ -37,11 +37,11 @@ func ParseLsPci(inputString string, includeFriendlyNames bool) ([]types.PciDevic
 				// Parse slot value into bus number: 0000:3b:00.0 -> 3B
 				parts := strings.Split(value, ":")
 				if len(parts) != 3 {
-					return nil, fmt.Errorf("unexpected format for pci slot: %s", value)
+					return nil, fmt.Errorf("pci slot: %s", value)
 				}
 				busNumber, err := strconv.ParseUint(parts[1], 16, 8)
 				if err != nil {
-					return nil, fmt.Errorf("cannot parse pci bus number: %s", parts[1])
+					return nil, fmt.Errorf("bus number: %s", parts[1])
 				}
 				device.BusNumber = types.HexInt(busNumber)
 			case "Class":
@@ -80,7 +80,7 @@ func ParseLsPci(inputString string, includeFriendlyNames bool) ([]types.PciDevic
 			friendlyNames, err := friendlyNames(device)
 			if err != nil {
 				// This is not a fatal error, so just logging it
-				fmt.Fprintln(os.Stderr, "Error looking up friendly name:", err)
+				fmt.Fprintln(os.Stderr, "Warning: failed to look up PCI names:", err)
 			} else {
 				device.PciFriendlyNames = friendlyNames
 			}

--- a/pkg/hardware_info/pci/nvidia/gpu.go
+++ b/pkg/hardware_info/pci/nvidia/gpu.go
@@ -21,7 +21,7 @@ func gpuProperties(pciDevice types.PciDevice) (map[string]string, error) {
 
 	vRamVal, err := vRam(pciDevice)
 	if err != nil {
-		return nil, fmt.Errorf("error looking up vRAM: %v", err)
+		return nil, fmt.Errorf("vRAM: %v", err)
 	}
 	if vRamVal != nil {
 		properties["vram"] = strconv.FormatUint(*vRamVal, 10)
@@ -29,7 +29,7 @@ func gpuProperties(pciDevice types.PciDevice) (map[string]string, error) {
 
 	ccVal, err := computeCapability(pciDevice)
 	if err != nil {
-		return nil, fmt.Errorf("error looking up compute capability: %v", err)
+		return nil, fmt.Errorf("compute capability: %v", err)
 	}
 	if ccVal != nil {
 		properties["compute-capability"] = *ccVal
@@ -49,7 +49,7 @@ func vRam(device types.PciDevice) (*uint64, error) {
 	*/
 	output, err := nvidiaSmi("--id="+device.Slot, "--query-gpu=memory.total", "--format=csv,noheader")
 	if err != nil {
-		return nil, fmt.Errorf("error executing nvidia-smi: %s", err)
+		return nil, fmt.Errorf("nvidia-smi: %s", err)
 	}
 
 	valueStr, unit, hasUnit := strings.Cut(*output, " ")
@@ -77,7 +77,7 @@ func computeCapability(device types.PciDevice) (*string, error) {
 	// nvidia-smi --query-gpu=compute_cap --format=csv,noheader
 	output, err := nvidiaSmi("--id="+device.Slot, "--query-gpu=compute_cap", "--format=csv,noheader")
 	if err != nil {
-		return nil, fmt.Errorf("error executing nvidia-smi: %s", err)
+		return nil, fmt.Errorf("nvidia-smi: %s", err)
 	}
 
 	return output, nil

--- a/pkg/hardware_info/pci/nvidia/nvidia.go
+++ b/pkg/hardware_info/pci/nvidia/nvidia.go
@@ -20,7 +20,7 @@ func AdditionalProperties(pciDevice types.PciDevice) (map[string]string, error) 
 	if pciDevice.DeviceClass == 0x0001 || pciDevice.DeviceClass&0xFF00 == 0x0300 {
 		properties, err = gpuProperties(pciDevice)
 		if err != nil {
-			return nil, fmt.Errorf("error getting gpu properties: %v", err)
+			return nil, fmt.Errorf("%v", err)
 		}
 	}
 

--- a/pkg/hardware_info/pci/pci_devices.go
+++ b/pkg/hardware_info/pci/pci_devices.go
@@ -25,11 +25,11 @@ func Devices(friendlyNames bool) ([]types.PciDevice, error) {
 
 	hostLsPciData, err := hostLsPci()
 	if err != nil {
-		return nil, fmt.Errorf("error getting host lspci data: %v", err)
+		return nil, fmt.Errorf("getting lspci data: %v", err)
 	}
 	devices, err := ParseLsPci(hostLsPciData, friendlyNames)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing lspci data: %v", err)
+		return nil, fmt.Errorf("parsing lspci data: %v", err)
 	}
 
 	// Additional properties are obtained by running vendor specific tools on the host
@@ -42,7 +42,7 @@ func Devices(friendlyNames bool) ([]types.PciDevice, error) {
 func DevicesFromRawData(lspciData string, friendlyNames bool) ([]types.PciDevice, error) {
 	devices, err := ParseLsPci(lspciData, friendlyNames)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing lspci data: %v", err)
+		return nil, fmt.Errorf("parsing lspci data: %v", err)
 	}
 
 	return devices, nil
@@ -59,7 +59,7 @@ func friendlyNames(device types.PciDevice) (types.PciFriendlyNames, error) {
 		var err error
 		pciDb, err = pcidb.New(pcidb.WithEnableNetworkFetch())
 		if err != nil {
-			return friendlyNames, fmt.Errorf("error opening pci database: %v", err)
+			return friendlyNames, fmt.Errorf("opening pci database: %v", err)
 		}
 	}
 
@@ -122,7 +122,7 @@ func addAdditionalProperties(devices []types.PciDevice) []types.PciDevice {
 			if errors.Is(err, ErrorVendorNotSupported) {
 				// We do not log unsupported vendors, as that would be the majority of PCI devices
 			} else {
-				fmt.Fprintf(os.Stderr, "Error getting additional properties for pci device: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Warning: additional properties: %v\n", err)
 			}
 		}
 		devices[i].AdditionalProperties = properties

--- a/pkg/selector/pci/pci.go
+++ b/pkg/selector/pci/pci.go
@@ -147,7 +147,7 @@ func scorePciDevice(manifestDevice engines.Device, hostPciDevice types.PciDevice
 		connected, err := checkSnapConnection(connection)
 		if err != nil {
 			deviceScore = 0
-			issues = append(issues, fmt.Sprintf("error checking snap connection %q: %v", connection, err))
+			issues = append(issues, fmt.Sprintf("snap connection %q: %v", connection, err))
 			return
 		}
 		if !connected {

--- a/pkg/selector/pci/properties.go
+++ b/pkg/selector/pci/properties.go
@@ -42,7 +42,7 @@ func checkVram(device engines.Device, pciDevice types.PciDevice) error {
 	if vram, ok := pciDevice.AdditionalProperties["vram"]; ok {
 		vramAvailable, err := utils.StringToBytes(vram)
 		if err != nil {
-			return fmt.Errorf("error parsing vRAM: %v", err)
+			return fmt.Errorf("parsing vRAM: %v", err)
 		}
 		if vramAvailable >= vramRequired {
 			return nil

--- a/pkg/selector/select_stack.go
+++ b/pkg/selector/select_stack.go
@@ -70,7 +70,7 @@ func checkEngine(hardwareInfo *types.HwInfo, manifest engines.Manifest) (int, en
 	if manifest.Memory != nil {
 		requiredMemory, err := utils.StringToBytes(*manifest.Memory)
 		if err != nil {
-			return 0, compatibilityReport, fmt.Errorf("failed to parse required memory: %v", err)
+			return 0, compatibilityReport, fmt.Errorf("parsing required memory: %v", err)
 		}
 
 		if hardwareInfo.Memory.TotalRam == 0 {
@@ -97,7 +97,7 @@ func checkEngine(hardwareInfo *types.HwInfo, manifest engines.Manifest) (int, en
 		requiredDisk, err := utils.StringToBytes(*manifest.DiskSpace)
 
 		if err != nil {
-			return 0, compatibilityReport, fmt.Errorf("failed to parse required disk space: %v", err)
+			return 0, compatibilityReport, fmt.Errorf("parsing required disk space: %v", err)
 		}
 
 		if _, ok := hardwareInfo.Disk[constants.SnapStoragePath]; !ok {

--- a/pkg/snap_store/snap_store.go
+++ b/pkg/snap_store/snap_store.go
@@ -13,7 +13,7 @@ import (
 func ComponentSizes() (map[string]int64, error) {
 	components, err := componentsOfCurrentSnap()
 	if err != nil {
-		return nil, fmt.Errorf("error finding components of current snap: %v", err)
+		return nil, fmt.Errorf("components sizes: %v", err)
 	}
 
 	componentSizes := make(map[string]int64)
@@ -41,17 +41,17 @@ func componentsOfCurrentSnap() ([]snapResources, error) {
 
 	snapRevision, err := strconv.ParseInt(snapRevisionStr, 10, 64)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing snap revision: %v", err)
+		return nil, fmt.Errorf("parsing snap revision: %v", err)
 	}
 
 	info, err := snapInfo(snapName)
 	if err != nil {
-		return nil, fmt.Errorf("error getting snap info: %v", err)
+		return nil, fmt.Errorf("getting snap info: %v", err)
 	}
 
 	components, err := snapComponents(info.SnapId, int(snapRevision), os.Getenv("SNAP_ARCH"))
 	if err != nil {
-		return nil, fmt.Errorf("error getting components: %v", err)
+		return nil, fmt.Errorf("getting components: %v", err)
 	}
 
 	return components, nil
@@ -64,7 +64,7 @@ func snapInfo(snapName string) (*snapInfoResponse, error) {
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error creating new http request: %v", err)
+		return nil, fmt.Errorf("creating new http request: %v", err)
 	}
 
 	req.Header.Add("Snap-Device-Series", "16")
@@ -73,7 +73,7 @@ func snapInfo(snapName string) (*snapInfoResponse, error) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("error making HTTP request: %v", err)
+		return nil, fmt.Errorf("HTTP request: %v", err)
 	}
 	defer resp.Body.Close()
 
@@ -84,7 +84,7 @@ func snapInfo(snapName string) (*snapInfoResponse, error) {
 	info := snapInfoResponse{}
 	err = json.NewDecoder(resp.Body).Decode(&info)
 	if err != nil {
-		return nil, fmt.Errorf("error decoding JSON: %v", err)
+		return nil, fmt.Errorf("json: %v", err)
 	}
 
 	return &info, nil
@@ -97,7 +97,7 @@ func snapComponents(snapId string, revision int, snapArch string) ([]snapResourc
 	*/
 	refreshResponse, err := snapRefresh(snapId, revision, snapArch)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching refresh data from store: %v", err)
+		return nil, fmt.Errorf("refresh data: %v", err)
 	}
 
 	if len(refreshResponse.Results) == 0 {
@@ -136,14 +136,14 @@ func snapRefresh(snapId string, revision int, snapArch string) (*snapRefreshResp
 	}
 	requestJson, err := json.Marshal(request)
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling request to json: %v", err)
+		return nil, fmt.Errorf("json: %v", err)
 	}
 
 	url := "https://api.snapcraft.io/v2/snaps/refresh"
 
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(requestJson))
 	if err != nil {
-		return nil, fmt.Errorf("error creating new http request: %v", err)
+		return nil, fmt.Errorf("new http request: %v", err)
 	}
 
 	req.Header.Add("Snap-Device-Series", "16")
@@ -154,7 +154,7 @@ func snapRefresh(snapId string, revision int, snapArch string) (*snapRefreshResp
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("error making HTTP request: %v", err)
+		return nil, fmt.Errorf("HTTP request: %v", err)
 	}
 	defer resp.Body.Close()
 
@@ -165,7 +165,7 @@ func snapRefresh(snapId string, revision int, snapArch string) (*snapRefreshResp
 	var response snapRefreshResponse
 	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
-		return nil, fmt.Errorf("error decoding JSON: %v", err)
+		return nil, fmt.Errorf("json: %v", err)
 	}
 
 	return &response, nil

--- a/pkg/storage/config.go
+++ b/pkg/storage/config.go
@@ -48,7 +48,7 @@ func (c *config) Set(key, value string, confType configType) error {
 	if confType == UserConfig {
 		valMap, err := c.Get(key)
 		if err != nil {
-			return fmt.Errorf("error checking existing keys: %s", err)
+			return fmt.Errorf("checking key: %s", err)
 		}
 		if len(valMap) == 0 {
 			return fmt.Errorf("unknown key")


### PR DESCRIPTION
<details>

<summary>Errors before change</summary>

# inference-snaps-cli — Complete Error Reference

All errors produced by first-party code, with their **full literal output** as seen by the user.
Errors from external packages are the boundary; they are listed as the leaf cause but not traced further.

## How cobra formats errors

`SilenceUsage: true` is set on the root command; `SilenceErrors` is **not** set.
Every error returned by a `RunE` (or `PersistentPreRunE`) function is printed to **stderr** by cobra as:

```
Error: <err.Error()>
```

followed, only when a command/flag parse fails (not a `RunE` error), by:

```
Run '<command> --help' for usage.
```

Errors printed directly with `fmt.Printf`/`fmt.Fprintf` are noted explicitly. All other entries in
this document represent errors that cobra prefixes with `Error: `.

---

## Table of Contents
1. [cmd/cli/main.go](#1-cmdclimaingo)
2. [cmd/cli/commands/](#2-cmdclicommands)
   - [use-engine.go](#21-use-enginego)
   - [list-engines.go](#22-list-enginesgo)
   - [show-engine.go](#23-show-enginego)
   - [status.go](#24-statusgo)
   - [chat.go](#25-chatgo)
   - [get.go](#26-getgo)
   - [set.go](#27-setgo)
   - [prune-cache.go](#28-prune-cachego)
   - [run.go](#29-rungo)
   - [show-machine.go](#210-show-machinego)
   - [version.go](#211-versiongo)
   - [debug/validate.go](#212-debugvalidatego)
   - [debug/select.go](#213-debugselectgo)
   - [debug/chat.go](#214-debugchatgo)
3. [cmd/cli/common/](#3-cmdclicommon)
   - [engine.go](#31-enginego)
   - [endpoints.go](#32-endpointsgo)
   - [component.go](#33-componentgo)
   - [errors.go](#34-errorsgo)
4. [pkg/engines/](#4-pkgengines)
   - [load.go](#41-loadgo)
   - [validate.go](#42-validatego)
   - [devices.go](#43-devicesgo)
   - [busses.go](#44-bussesgo)
   - [cpu.go](#45-cpugo)
5. [pkg/selector/](#5-pkgselector)
   - [select_stack.go](#51-select_stackgo)
   - [pci/pci.go](#52-pcipciго)
   - [pci/properties.go](#53-pcipropertiesgo)
6. [pkg/hardware_info/](#6-pkghardware_info)
   - [hardware-info.go](#61-hardware-infogo)
   - [memory/](#62-memory)
   - [cpu/](#63-cpu)
   - [disk/](#64-disk)
   - [pci/pci_devices.go](#65-pcipci_devicesgo)
   - [pci/lspci.go](#66-pcilspcigo)
   - [pci/nvidia/](#67-pcinvidia)
   - [pci/amd/](#68-pciamd)
   - [pci/intel/](#69-pciintel)
7. [pkg/snap_store/snap_store.go](#7-pkgsnap_storesnap_storego)
8. [pkg/storage/](#8-pkgstorage)
   - [cache.go](#81-cachego)
   - [config.go](#82-configgo)
   - [snapctl_storage.go](#83-snapctl_storagego)
9. [pkg/utils/utils.go](#9-pkgutilsutilsgo)

---

## 1. `cmd/cli/main.go`

These are printed **directly** with `fmt.Printf` (not through cobra), so there is no cobra `Error:` prefix added — but the strings themselves include `"Error: "`.

| Full stdout output | Condition |
|---|---|
| `Error: could not retrieve snap services: <snapctl error>` | `snapctl.Services().Run()` fails at startup; printed to stdout then `return` |
| `Error: <err>` | `appendCommandToGroup` fails (group ID `"basic"` not found — programming invariant); printed to stdout then `return` |

`PersistentPreRunE` can return one error (cobra then prints it to stderr):

| Full stderr output | Condition |
|---|---|
| `Error: <os.Setenv error>` | `os.Setenv("VERBOSE", "true")` fails when `--verbose` is passed |

---

## 2. `cmd/cli/commands/`

### 2.1 `use-engine.go`

> Shell-completion helper `validateArgs` prints directly to **stdout** (not through cobra RunE):
> `Error loading engines: <LoadManifests error>`

#### `run()` — returned to cobra → stderr

| Full stderr output | Condition |
|---|---|
| `Error: permission denied, try again with sudo` | Not root user |
| `Error: cannot specify both engine name and --auto flag` | `--auto` used with a positional argument |
| `Error: cannot specify both engine name and --fix flag` | `--fix` used with a positional argument |
| `Error: engine name not specified` | No `--auto`, no `--fix`, and no positional argument |

#### `autoSelectEngine()` → propagated to `run()` → stderr

| Full stderr output | Condition |
|---|---|
| `Error: error checking engines: <ScoreEngines error>` | `common.ScoreEngines` fails — see [§3.1](#31-enginego) |
| `Error: error finding top engine: no compatible engines found` | No stable, compatible engine exists |
| `Error: failed to use engine: <switchEngine error>` | `switchEngine` fails — see below |

#### `switchEngine(engineName)` → propagated via `autoSelectEngine` or `run()` → stderr

| Full stderr output | Condition |
|---|---|
| `Error: failed to use engine: "<name>" not found` | `engines.ErrManifestNotFound` |
| `Error: failed to use engine: error loading engine manifest: <OS/YAML error>` | Other manifest load error |
| `Error: failed to use engine: error installing missing components: <error>` | `installMissingComponents` fails — see below |
| `Error: failed to use engine: error getting active engine: <snapctl error>` | `Cache.GetActiveEngine()` fails |
| `Error: failed to use engine: error un-setting engine configurations: <snapctl error>` | `Config.Unset(".", EngineConfig)` fails |
| `Error: failed to use engine: error loading engine manifest: <OS/YAML error>` | Manifest load error inside `UnsetEngineConfig` |
| `Error: failed to use engine: error un-setting configuration "<key>": <snapctl error>` | `Config.Unset(k, UserConfig)` fails |
| `Error: failed to use engine: error setting active engine: <snapctl error>` | `Cache.SetActiveEngine` fails |
| `Error: failed to use engine: error setting new engine configurations: <snapctl error>` | `SetEngineConfig` → `Config.SetDocument` fails |

#### `installMissingComponents(engine)` → wrapped as `"error installing missing components: %v"`

| Full stderr output | Condition |
|---|---|
| `Error: failed to use engine: error installing missing components: error checking installed components: error checking component directory "<comp>": <os error>` | `os.Stat` on a component dir fails with non-ErrNotExist |
| `Error: failed to use engine: error installing missing components: error checking installed components: component "<comp>" exists but is not a directory` | Component path is a file |
| `Error: failed to use engine: error installing missing components: timed out while installing "<comp>":\nMonitor the installation progress with "snap changes"\n\nRerun this command once the installation is complete` | 60-minute install timeout exceeded |
| `Error: failed to use engine: error installing missing components: snap not known to the store:\nRerun this command after manually installing "<comp>"` | snapctl reports snap unknown to store |
| `Error: failed to use engine: error installing missing components: error installing "<comp>": <snapctl error>` | Any other `snapctl.InstallComponents` error |
| `Error: failed to use engine: error installing components: <error>` | `installComponents` fails (from the outer `installMissingComponents`) |

#### `fixActiveEngine()` → propagated to `run()` → stderr

| Full stderr output | Condition |
|---|---|
| `Error: error getting active engine: <snapctl error>` | `Cache.GetActiveEngine()` fails |
| `Error: no active engine to fix` | Active engine name is empty |
| `Error: error loading active engine manifest: <OS/YAML error>` | Other manifest load error (non-ErrManifestNotFound) |
| `Error: error installing missing components: <error>` | `installMissingComponents` fails |
| `Error: error un-setting engine configurations: <error>` | `UnsetEngineConfig` fails |
| `Error: error setting engine configurations: <error>` | `SetEngineConfig` fails |

#### Non-fatal, printed directly to stderr (no cobra prefix)

| Full stderr output | Condition |
|---|---|
| `Warning: unable to get component sizes: <snap_store error>` | `snap_store.ComponentSizes()` fails (always includes error detail) |

---

### 2.2 `list-engines.go`

| Full stderr output | Condition |
|---|---|
| `Error: error checking engines: <ScoreEngines error>` | `common.ScoreEngines` fails — see [§3.1](#31-enginego) |
| `Error: could not determine active engine: <snapctl error>` | `Cache.GetActiveEngine()` fails |
| `Error: unknown format "<value>"` | `--format` value is not `"table"` or `"json"` |
| `Error: error marshalling engines to json: <json error>` | `json.MarshalIndent` fails |
| `Error: error printing list: <tablewriter error>` | `tablewriter.Bulk` or `Render` fails (table path) |
| `Error: error printing list: <json error>` | `printEnginesJson` fails (json path) |
| `Error: error adding data to table: <tablewriter error>` | `tablewriter.Bulk` fails |
| `Error: error rendering table: <tablewriter error>` | `tablewriter.Render` fails |

Non-fatal, printed directly to stderr:

| Full stderr output | Condition |
|---|---|
| `No engines found.` | Engine list is empty |

---

### 2.3 `show-engine.go`

> Shell-completion helper `validateArgs` prints directly to **stdout** (not through cobra RunE):
> `Error loading engines: <LoadManifests error>`

| Full stderr output | Condition |
|---|---|
| `Error: invalid number of arguments` | More than 1 positional argument (cobra `MaximumNArgs(1)` prevents this in practice) |
| `Error: could not get the active engine: <snapctl error>` | `Cache.GetActiveEngine()` fails (no-arg path) |
| `Error: no active engine` | Active engine name is empty |
| `Error: error checking engines: <ScoreEngines error>` | `common.ScoreEngines` fails — see [§3.1](#31-enginego) |
| `Error: engine "<name>" does not exist` | Engine name not in scored list |
| `Error: error printing engine manifest: <format error>` | `printEngineManifest` fails |
| `Error: failed to marshal to JSON: <json error>` | `json.MarshalIndent` fails |
| `Error: failed to marshal to YAML: <yaml error>` | `yaml.Marshal` fails |
| `Error: unknown format "<value>"` | `--format` is not `"json"` or `"yaml"` |

---

### 2.4 `status.go`

| Full stderr output | Condition |
|---|---|
| `Error: unknown format "<value>"` | `--format` is not `"json"` or `"yaml"` |
| `Error: error getting json status: <statusStruct error>` | `statusStruct()` fails (json path) |
| `Error: error getting yaml status: <statusStruct error>` | `statusStruct()` fails (yaml path) |
| `Error: error getting status: <statusStruct error>` | `statusStruct()` fails (inner propagation) |
| `Error: error marshalling yaml: <yaml error>` | `yaml.Marshal` of the status struct fails |
| `Error: error marshalling json: <json error>` | `json.MarshalIndent` of the status struct fails |
| `Error: error getting active engine: <snapctl error>` | `Cache.GetActiveEngine()` fails |
| `Error: error no engine is active` | Active engine name is empty |
| `Error: error getting services: <snapctl error>` | `snapctl.Services().Run()` fails |
| `Error: error unexpected service name format: "<name>"` | A service name has no `.` separator |
| `Error: error getting server api endpoints: <ServerEndpoints error>` | `common.ServerEndpoints` fails — see [§3.2](#32-endpointsgo) |

---

### 2.5 `chat.go`

| Full stderr output | Condition |
|---|---|
| `Error: error getting OpenAI base URL: <ServerEndpoints error>` | `common.ServerEndpoints` fails — see [§3.2](#32-endpointsgo) |
| `Error: "openai" not found in server endpoints` | No `openai` key in the endpoints map |
| `Error: error getting services: <snapctl error>` | `snapctl.Services(serviceName).Run()` fails |
| `Error: server not active\n\n<suggestion string>` | The `.server` service `Current` state is `"inactive"` |
| `Error: error initializing readline: <error>` | `readline.NewEx` fails |
| `Error: invalid base URL: <url.Parse error>` | `url.Parse(baseUrl)` fails in `handshake` |
| `Error: connection refused\n\n<suggest-start>\n<suggest-logs>` | TCP dial to server is refused in `handshake` |
| `Error: no models available on server\n\n<suggest-start>\n<suggest-logs>` | Server returns 503 `unavailable_error` for >60 s in `checkServerReady` |
| `Error: api: <api error>` | Server returns a non-503 API error in `checkServerReady` or `lookupModelName` |
| `Error: <other error>\n\n<suggest-logs>` | Any other error in `checkServerReady` or `lookupModelName` |
| `Error: no models available on server\n\n<suggest-start>\n<suggest-logs>` | Server 503 for >60 s in `lookupModelName` |
| `Error: server returned no models\n\n<suggest-start>\n<suggest-logs>` | Model list empty for >60 s in `lookupModelName` |
| `Error: expected one but server returned multiple models: <name1>, <name2>` | Server lists >1 model and `--model` not specified |
| `Error: connection refused\n\n<suggest-logs>` | TCP connection refused mid-stream in `processStream` |
| `Error: connection closed by server\n\n<suggest-logs>` | Unexpected EOF mid-stream in `processStream` |
| `Error: <stream error>\n\n<suggest-logs>` | Any other streaming error in `processStream` |

---

### 2.6 `get.go`

| Full stderr output | Condition |
|---|---|
| `Error: error getting value of "<key>": <snapctl error>` | `Config.Get(key)` fails |
| `Error: no value set for key "<key>"` | Key has no stored value |
| `Error: error serializing value: <yaml error>` | `yaml.Marshal` fails on the single-key result |
| `Error: error getting values: <snapctl error>` | `Config.GetAll()` fails |
| `Error: error serializing values: <yaml error>` | `yaml.Marshal` fails on the full config map |

Non-fatal, printed directly to stderr:

| Full stderr output | Condition |
|---|---|
| `Note: "<key>" configuration field is deprecated!` | Requested key is in the deprecated-config list and output is a terminal |

---

### 2.7 `set.go`

| Full stderr output | Condition |
|---|---|
| `Error: permission denied, try again with sudo` | Not root user |
| `Error: key must not start with an equal sign` | First character of argument is `=` |
| `Error: expected key=value, got "<arg>"` | No `=` in the argument |
| `Error: "<key>" is read-only` | User tries to set a deprecated/internal config key |
| `Error: error setting value "<value>" for "<key>": <Config.Set error>` | `Config.Set` fails — see [§8.2](#82-configgo) |

---

### 2.8 `prune-cache.go`

| Full stderr output | Condition |
|---|---|
| `Error: permission denied, try again with sudo` | Not root user |
| `Error: <snapctl error>` | `Cache.GetActiveEngine()` fails (error returned unwrapped) |
| `Error: No active engine found` | `engines.ErrManifestNotFound` for the active engine |
| `Error: error loading engine manifest: <OS/YAML error>` | Other manifest load error for active engine |
| `Error: cannot prune the active engine "<name>"` | `--engine` value matches the active engine |
| `Error: "<name>" not found` | `engines.ErrManifestNotFound` for the named `--engine` |
| `Error: error loading engine manifest: <OS/YAML error>` | Other load error for named engine |
| `Error: failed to load manifests: <LoadManifests error>` | `engines.LoadManifests` fails inside `getAllComponentsToRemove` or `pruneAllInactiveEngines` |
| `Error: unable to get list of inactive engines: <error>` | `engines.LoadManifests` or `Cache.GetActiveEngine` fails inside `inactiveEngines()` |
| `Error: error checking component directory "<comp>": <os error>` | `os.Stat` fails with non-ErrNotExist inside `calculateRemovableComponents` |
| `Error: component "<comp>" exists but is not a directory` | Component path is a file inside `calculateRemovableComponents` |
| `Error: error un-setting engine configurations: <snapctl error>` | `Config.Unset(".", EngineConfig)` fails inside `pruneEngine` → `UnsetEngineConfig` |
| `Error: error loading engine manifest: <OS/YAML error>` | Manifest load error inside `UnsetEngineConfig` |
| `Error: error un-setting configuration "<key>": <snapctl error>` | `Config.Unset(k, UserConfig)` fails |
| `Error: failed to remove components: <snapctl error>` | `snapctl.RemoveComponents` fails |

Non-fatal, printed directly to **stdout** (no cobra prefix):

| Full stdout output | Condition |
|---|---|
| `Warning: unable to get component sizes: <snap_store error>` | `snap_store.ComponentSizes()` fails (always includes error detail) |

---

### 2.9 `run.go`

| Full stderr output | Condition |
|---|---|
| `Error: unexpected number of arguments, expected 1 got <n>` | Not exactly 1 positional argument |
| `Error: error waiting for component: <waitForComponents error>` | `waitForComponents` fails — see below |
| `Error: error loading engine environment: <LoadEngineEnvironment error>` | `common.LoadEngineEnvironment` fails — see [§3.1](#31-enginego) |
| Exec error from `execCmd.Run()` — `Error: <exec error>` | Subprocess exits non-zero |
| `Error: SNAP_COMPONENTS env var not set` | `SNAP_COMPONENTS` not in environment inside `checkMissingComponents` |
| `Error: error looking up active engine: <snapctl error>` | `Cache.GetActiveEngine()` fails inside `waitForComponents` |
| `Error: no active engine` | Active engine name is empty inside `waitForComponents` |
| `Error: error loading engine manifest: <OS/YAML error>` | Manifest load error inside `waitForComponents` |
| `Error: timed out after <n>s while waiting for required components: <comp1>, <comp2>` | Components not mounted after 3600 s |

---

### 2.10 `show-machine.go`

| Full stderr output | Condition |
|---|---|
| `Error: failed to get machine info: memory info: error reading /proc/meminfo: <os error>` | `/proc/meminfo` unreadable |
| `Error: failed to get machine info: memory info: error parsing MemTotal: error parsing kB value: <strconv error>` | MemTotal kB parse fails |
| `Error: failed to get machine info: memory info: error parsing MemTotal: error parsing byte value: <strconv error>` | MemTotal byte parse fails |
| `Error: failed to get machine info: memory info: error parsing SwapTotal: error parsing kB value: <strconv error>` | SwapTotal kB parse fails |
| `Error: failed to get machine info: memory info: error parsing SwapTotal: error parsing byte value: <strconv error>` | SwapTotal byte parse fails |
| `Error: failed to get machine info: cpu info: reading /proc/cpuinfo: <os error>` | `/proc/cpuinfo` unreadable |
| `Error: failed to get machine info: cpu info: getting host uname: <exec error>` | `uname --machine` fails |
| `Error: failed to get machine info: cpu info: unsupported architecture: <arch>` | `uname -m` not in lookup table |
| `Error: failed to get machine info: cpu info: unsupported architecture: <arch>` | Architecture from `/proc/cpuinfo` not `amd64`/`arm64` |
| `Error: failed to get machine info: cpu info: <strconv error>` | Integer field parse in `/proc/cpuinfo` fails |
| `Error: failed to get machine info: disk info: statfs failed: <os error>` | `unix.Statfs` fails |
| `Error: failed to get machine info: pci devices: getting lspci data: <exec error>` | `lspci -vmmnD` fails |
| `Error: failed to get machine info: pci devices: parsing lspci data: unexpected format for pci slot: <value>` | PCI slot has wrong format |
| `Error: failed to get machine info: pci devices: parsing lspci data: cannot parse pci bus number: <value>` | Bus-number hex parse fails |
| `Error: failed to marshal to JSON: <json error>` | `json.MarshalIndent` fails |
| `Error: failed to marshal to YAML: <yaml error>` | `yaml.Marshal` fails |
| `Error: unknown format "<value>"` | `--format` is not `"json"` or `"yaml"` |

---

### 2.11 `version.go`

| Full stderr output | Condition |
|---|---|
| `Error: failed to marshal to JSON: <json error>` | `json.MarshalIndent` fails |
| `Error: failed to marshal to YAML: <yaml error>` | `yaml.Marshal` fails |
| `Error: unknown format "<value>"` | `--format` is not `"json"` or `"yaml"` |

---

### 2.12 `debug/validate.go`

| Full stderr output | Condition |
|---|---|
| `Error: no engine manifest specified` | Zero positional arguments |
| `Error: not all manifests are valid` | At least one `engines.Validate` call returned an error |

Per-file errors are printed **directly to stdout** (not returned, no cobra prefix):

| Full stdout output | Condition |
|---|---|
| `❌ <path>: manifest file must be called engine.yaml: <path>` | File name doesn't end with `engine.yaml` |
| `❌ <path>: manifest file does not exist: <path>` | `os.Stat` → ErrNotExist |
| `❌ <path>: getting file info: <os error>` | `os.Stat` fails for any other reason |
| `❌ <path>: reading file: <os error>` | `os.ReadFile` fails |
| `❌ <path>: empty yaml data` | File is empty after trimming |
| `❌ <path>: yaml: <yaml error>` | YAML parse error or unknown field |
| `❌ <path>: required field is not set: name` | `name` field missing |
| `❌ <path>: engine directory name should match name in manifest: <dir> != <name>` | Directory name ≠ manifest name |
| `❌ <path>: required field is not set: description` | `description` field missing |
| `❌ <path>: required field is not set: vendor` | `vendor` field missing |
| `❌ <path>: required field is not set: grade` | `grade` field missing |
| `❌ <path>: grade should be 'stable' or 'devel'` | `grade` is set but invalid |
| `❌ <path>: parsing memory: <strconv error>` | `memory` value not a valid size string |
| `❌ <path>: parsing disk space: <strconv error>` | `disk-space` value not a valid size string |
| `❌ <path>: configuration field <key> is not a primitive value: <value>` | A configurations entry is non-primitive |
| `❌ <path>: invalid device: allof <n>/<total>: cpu: architecture field required` | CPU device in `allof` missing `architecture` |
| `❌ <path>: invalid device: allof <n>/<total>: cpu: invalid architecture: <value>` | Unknown architecture |
| `❌ <path>: invalid device: allof <n>/<total>: cpu: invalid field for amd64: <field>` | Invalid field for amd64 CPU |
| `❌ <path>: invalid device: allof <n>/<total>: cpu: invalid field for arm64: <field>` | Invalid field for arm64 CPU |
| `❌ <path>: invalid device: allof <n>/<total>: gpu: invalid bus: <value>` | Unknown bus type for GPU |
| `❌ <path>: invalid device: allof <n>/<total>: gpu: usb device validation not implemented` | GPU on USB bus |
| `❌ <path>: invalid device: allof <n>/<total>: gpu: pci device: invalid field: <field>` | Invalid field for PCI GPU |
| `❌ <path>: invalid device: allof <n>/<total>: npu: <bus/field error>` | NPU device errors (same bus/field patterns) |
| `❌ <path>: invalid device: allof <n>/<total>: typeless: <bus/field error>` | Typeless device errors |
| `❌ <path>: invalid device: allof <n>/<total>: invalid device type: <value>` | `type` not `cpu`, `gpu`, `npu`, or `""` |
| *(same set with `anyof` instead of `allof`)* | Same errors for `anyof` devices |
| `✅ <path>` | Manifest is valid |

---

### 2.13 `debug/select.go`

| Full stderr output | Condition |
|---|---|
| `Error: error decoding hardware info: <yaml error>` | `yaml.Decode` on stdin fails |
| `Error: error loading engines from directory: <LoadManifests error>` | `engines.LoadManifests` fails — see [§4.1](#41-loadgo) |
| `Error: error checking engines: parsing required memory: <strconv error>` | `utils.StringToBytes` fails for a manifest memory field |
| `Error: error checking engines: total memory not reported by host system` | `hardwareInfo.Memory.TotalRam == 0` |
| `Error: error checking engines: parsing required disk space: <strconv error>` | `utils.StringToBytes` fails for a manifest disk-space field |
| `Error: error checking engines: disk space not reported by host system` | Snap storage path not in disk info map |
| `Error: error finding top engine: no compatible engines found` | No stable compatible engine |
| `Error: failed to marshal to JSON: <json error>` | `json.MarshalIndent` fails |
| `Error: failed to marshal to YAML: <yaml error>` | `yaml.Marshal` fails |
| `Error: unknown format "<value>"` | `--format` is not `"json"` or `"yaml"` |

---

### 2.14 `debug/chat.go`

| Full stderr output | Condition |
|---|---|
| `Error: the --base-url parameter is required` | `--base-url` flag not provided |
| `Error: error initializing readline: <error>` | `readline.NewEx` fails |
| `Error: invalid base URL: <url.Parse error>` | `url.Parse(baseUrl)` fails in `handshake` |
| `Error: connection refused\n\n<suggest-start>\n<suggest-logs>` | TCP dial to server is refused |
| `Error: no models available on server\n\n<suggest-start>\n<suggest-logs>` | Server 503 `unavailable_error` for >60 s in `checkServerReady` or `lookupModelName` |
| `Error: api: <api error>` | Server returns a non-503 API error |
| `Error: <other error>\n\n<suggest-logs>` | Any other error from `checkServerReady` or `lookupModelName` |
| `Error: server returned no models\n\n<suggest-start>\n<suggest-logs>` | Model list empty for >60 s |
| `Error: expected one but server returned multiple models: <name1>, <name2>` | Server lists >1 model and `--model` not specified |
| `Error: connection refused\n\n<suggest-logs>` | TCP connection refused mid-stream |
| `Error: connection closed by server\n\n<suggest-logs>` | Unexpected EOF mid-stream |
| `Error: <stream error>\n\n<suggest-logs>` | Any other streaming error |

---

## 3. `cmd/cli/common/`

### 3.1 `engine.go`

These errors are propagated up through callers and ultimately reach cobra, which prefixes them with `Error: `.
The tables below show the message fragment that each function contributes; callers add their own prefix before it.

#### `EngineComponentSettings(ctx)` errors

| Error message fragment | Condition |
|---|---|
| `error looking up active engine: <snapctl error>` | `Cache.GetActiveEngine()` fails |
| `no active engine` | Active engine name is empty |
| `error loading engine manifest: <OS/YAML error>` | Manifest load error — see [§4.1](#41-loadgo) |
| `SNAP_COMPONENTS env var not set` | `SNAP_COMPONENTS` not in environment |
| `error reading <path>: <os error>` | `os.ReadFile` fails on a component's `component.yaml` |
| `error unmarshaling <path>: <yaml error>` | `yaml.Unmarshal` fails on `component.yaml` |

#### `LoadEngineEnvironment(ctx)` errors

| Error message fragment | Condition |
|---|---|
| `error loading engine component settings: <EngineComponentSettings error>` | `EngineComponentSettings` fails |
| `SNAP_COMPONENTS env var not set` | Second check, inside the env-expansion loop |
| `invalid env var "<entry>"` | Env entry in component YAML has no `=` |
| `error setting "COMPONENT": <os error>` | `os.Setenv(COMPONENT, ...)` fails |
| `error unsetting "COMPONENT": <os error>` | `os.Unsetenv(COMPONENT)` fails |
| `error setting "<key>": <os error>` | `os.Setenv(k, v)` fails |

#### `SetEngineConfig(engine, ctx)` errors

| Error message fragment | Condition |
|---|---|
| `error setting engine configuration "<key>": <snapctl error>` | `Config.SetDocument` fails |

#### `UnsetEngineConfig(engineName, unsetUserOverrides, ctx)` errors

| Error message fragment | Condition |
|---|---|
| `error un-setting engine configurations: <snapctl error>` | `Config.Unset(".", EngineConfig)` fails |
| `error loading engine manifest: <OS/YAML error>` | Manifest load error when `unsetUserOverrides=true` |
| `error un-setting configuration "<key>": <snapctl error>` | `Config.Unset(k, UserConfig)` fails |

Non-fatal, printed directly to stderr (no cobra prefix):

| Full stderr output | Condition |
|---|---|
| `Warning: previously active engine "<name>" not found; skipping user configuration cleanup.` | `engines.ErrManifestNotFound` when `unsetUserOverrides=true` |

#### `ScoreEngines(ctx)` errors

| Error message fragment | Condition |
|---|---|
| `error loading engines: <LoadManifests error>` | `engines.LoadManifests` fails — see [§4.1](#41-loadgo) |
| `error getting machine info: <hardware_info.Get error>` | `hardware_info.Get(false)` fails — see [§6.1](#61-hardware-infogo) |
| `error scoring engines: <ScoreEngines error>` | `selector.ScoreEngines` fails — see [§5.1](#51-select_stackgo) |

---

### 3.2 `endpoints.go`

#### `ServerEndpoints(ctx)` / `serverEndpoints()` / `serverHttpUrl()` errors

| Error message fragment | Condition |
|---|---|
| `error loading engine environment: <EngineComponentSettings error>` | `EngineComponentSettings` fails |
| `OPENAI_BASE_PATH env in component "<name>" is deprecated; set server settings in "servers".` | Deprecated env key found |
| `error getting server HTTP URL: <serverHttpUrl error>` | `serverHttpUrl` fails |
| `unsupported protocol "<proto>" for server "<server>" in component "<comp>"` | Protocol not `"http"` or `"https"` |
| `error getting "http.port": <snapctl error>` | `Config.Get("http.port")` fails |

---

### 3.3 `component.go`

#### `ComponentInstalled(component)` errors

| Error message fragment | Condition |
|---|---|
| `error checking component directory "<comp>": <os error>` | `os.Stat` fails with non-ErrNotExist |
| `component "<comp>" exists but is not a directory` | Path exists but is a regular file |

---

### 3.4 `errors.go`

| Sentinel | Full value |
|---|---|
| `common.ErrPermissionDenied` | `permission denied, try again with sudo` |

---

## 4. `pkg/engines/`

### 4.1 `load.go`

#### `LoadManifests(manifestsDir)` errors

| Error message fragment | Condition |
|---|---|
| `<manifestsDir>: <os error>` | `os.ReadDir(manifestsDir)` fails |
| `<file path>: <os error>` | `os.ReadFile` fails on an engine YAML |
| `<manifestsDir>: <yaml error>` | `yaml.Unmarshal` fails on an engine YAML |

#### `LoadManifest(manifestsDir, engineName)` errors

| Error message fragment | Condition |
|---|---|
| `engine manifest not found: <os ErrNotExist>` | File does not exist; wraps `ErrManifestNotFound` |
| `<file path>: <os error>` | `os.ReadFile` fails for any other reason |
| `<manifestsDir>: <yaml error>` | `yaml.Unmarshal` fails |

---

### 4.2 `validate.go`

Errors from `Validate` are used by `debug/validate` (printed per-file, see [§2.12](#212-debugvalidatego)) and by `LoadManifest`; they are not surfaced directly by cobra.

| Error message fragment | Condition |
|---|---|
| `manifest file must be called engine.yaml: <path>` | Wrong filename |
| `manifest file does not exist: <path>` | File missing |
| `getting file info: <os error>` | `os.Stat` non-ErrNotExist |
| `reading file: <os error>` | `os.ReadFile` fails |
| `empty yaml data` | File is empty after trimming |
| `yaml: <yaml error>` | YAML parse error or unknown field |
| `required field is not set: name` | `name` missing |
| `engine directory name should match name in manifest: <dir> != <name>` | Name mismatch |
| `required field is not set: description` | `description` missing |
| `required field is not set: vendor` | `vendor` missing |
| `required field is not set: grade` | `grade` missing |
| `grade should be 'stable' or 'devel'` | Invalid grade value |
| `parsing memory: <strconv error>` | `memory` value invalid |
| `parsing disk space: <strconv error>` | `disk-space` value invalid |
| `configuration field <key> is not a primitive value: <value>` | Non-primitive configurations entry |
| `invalid device: allof <n>/<total>: <device error>` | Device in `allof` invalid |
| `invalid device: anyof <n>/<total>: <device error>` | Device in `anyof` invalid |

---

### 4.3 `devices.go`

| Error message fragment | Condition |
|---|---|
| `invalid device: allof <n>/<total>: <device error>` | A device in `allof` fails its own `validate()` |
| `invalid device: anyof <n>/<total>: <device error>` | A device in `anyof` fails its own `validate()` |
| `cpu: <cpu error>` | `validateCpu()` fails — see [§4.5](#45-cpugo) |
| `gpu: <bus/field error>` | `validateGpu()` fails — see [§4.4](#44-bussesgo) |
| `npu: <bus/field error>` | `validateNpu()` fails — see [§4.4](#44-bussesgo) |
| `typeless: <bus/field error>` | `validateTypelessDevice()` fails — see [§4.4](#44-bussesgo) |
| `invalid device type: <value>` | `type` field is not `cpu`, `gpu`, `npu`, or `""` |

---

### 4.4 `busses.go`

| Error message fragment | Condition |
|---|---|
| `invalid bus: <value>` | `bus` field is not `"pci"`, `"usb"`, or `""` |
| `usb device validation not implemented` | `bus == "usb"` |
| `pci device: invalid field: <field>` | A non-zero struct field is not in the PCI allow-list |

---

### 4.5 `cpu.go`

| Error message fragment | Condition |
|---|---|
| `architecture field required` | `device.Architecture == nil` |
| `invalid architecture: <value>` | Not `"amd64"` or `"arm64"` |
| `invalid field for amd64: <field>` | A non-zero struct field is not in the amd64 allow-list |
| `invalid field for arm64: <field>` | A non-zero struct field is not in the arm64 allow-list |

---

## 5. `pkg/selector/`

### 5.1 `select_stack.go`

#### `TopEngine(scoredEngines)` — sentinel

| Error message fragment | Condition |
|---|---|
| `no compatible engines found` | No engine with `Score > 0` and `Grade == "stable"` |

#### `checkEngine(hardwareInfo, manifest)` — returned through `ScoreEngines`

| Error message fragment | Condition |
|---|---|
| `parsing required memory: <strconv error>` | `utils.StringToBytes(*manifest.Memory)` fails |
| `total memory not reported by host system` | `hardwareInfo.Memory.TotalRam == 0` |
| `parsing required disk space: <strconv error>` | `utils.StringToBytes(*manifest.DiskSpace)` fails |
| `disk space not reported by host system` | Snap storage path not in disk info map |

*Device-level compatibility failures (wrong vendor, wrong type, etc.) are recorded as compatibility issues and reflected only in the score — they are never returned as errors.*

---

### 5.2 `pci/pci.go`

`Match` never returns an `error`. Incompatibility reasons are returned as `[]string` device issues, which surface in `CompatibilityIssues` fields and verbose output:

| Issue string | Condition |
|---|---|
| `no pci devices on host system` | `hostPciDevices` is empty |
| `device not found` | No device survives vendor/device ID filtering |
| `pci <slot>: vendor id mismatch: 0x<hex>` | Vendor ID doesn't match |
| `pci <slot>: device id mismatch: 0x<hex>` | Device ID doesn't match |
| `pci <slot>: device class 0x<hex> not of required type <type>` | Device class doesn't match required type |
| `pci <slot>: <err from checkProperties>` | Property check failure — see [§5.3](#53-pcipropertiesgo) |
| `pci <slot>: error checking snap connection "<conn>": <snapctl error>` | `snapctl.IsConnected` fails |
| `pci <slot>: "<conn>" is not connected` | Required snap interface not connected |
| `pci <slot>: no criteria met` | Device found but no scoring criterion matched |

---

### 5.3 `pci/properties.go`

Errors returned from `checkProperties` become issue strings in `pci.go` (prefixed with `pci <slot>: `).

| Error message fragment | Condition |
|---|---|
| `<strconv error>` | `utils.StringToBytes(*device.VRam)` fails — required vRAM is not a valid size string |
| `error parsing vRAM: <strconv error>` | `utils.StringToBytes(vram)` fails on the device-reported vRAM value |
| `not enough vRAM: <available bytes>` | Available vRAM < required |
| `unable to detect vRAM` | `"vram"` key absent from `AdditionalProperties` |
| `microarchitecture does not match: <actual>` | Microarch doesn't match required value |
| `unable to detect microarchitecture` | `"microarchitecture"` key absent from `AdditionalProperties` |

---

## 6. `pkg/hardware_info/`

### 6.1 `hardware-info.go`

#### `Get(friendlyNames)` errors — propagated up (prefixed by callers)

| Error message fragment | Condition |
|---|---|
| `memory info: <memory error>` | `memory.Info()` fails — see [§6.2](#62-memory) |
| `cpu info: <cpu error>` | `cpu.Info()` fails — see [§6.3](#63-cpu) |
| `disk info: <disk error>` | `disk.Info()` fails — see [§6.4](#64-disk) |
| `pci devices: <pci error>` | `pci.Devices(friendlyNames)` fails — see [§6.5](#65-pcipci_devicesgo) |

`show-machine` wraps with `"failed to get machine info: %s"`, so the full user-visible message is `Error: failed to get machine info: memory info: ...` etc. — see [§2.10](#210-show-machinego).
`common.ScoreEngines` wraps with `"error getting machine info: %v"`, so callers like `use-engine`, `list-engines`, and `show-engine` show `Error: error checking engines: error getting machine info: memory info: ...` etc.

---

### 6.2 `memory/`

#### `memory.Info()` / `parseProcMemInfo()` errors

| Error message fragment | Condition |
|---|---|
| `error reading /proc/meminfo: <os error>` | `os.ReadFile("/proc/meminfo")` fails |
| `error parsing MemTotal: error parsing kB value: <strconv error>` | `strconv.ParseInt` on the kB part of MemTotal fails |
| `error parsing MemTotal: error parsing byte value: <strconv error>` | `strconv.ParseInt` on a bare byte value of MemTotal fails |
| `error parsing SwapTotal: error parsing kB value: <strconv error>` | Same for SwapTotal |
| `error parsing SwapTotal: error parsing byte value: <strconv error>` | Same for SwapTotal |

---

### 6.3 `cpu/`

#### `cpu.Info()` / `InfoFromRawData()` / `parseProcCpuInfo()` / `debianArchitecture()` errors

| Error message fragment | Condition |
|---|---|
| `reading /proc/cpuinfo: <os error>` | `os.ReadFile("/proc/cpuinfo")` fails |
| `getting host uname: <exec error>` | `exec.Command("uname", "--machine")` fails |
| `unsupported architecture: <arch>` | `uname -m` not in the debian-arch lookup table |
| `unsupported architecture: <arch>` | Architecture string from `/proc/cpuinfo` not `"amd64"` or `"arm64"` |
| `<strconv error>` | Parsing integer fields (processor index, implementer-id, part-number, variant, revision, cpu-khz) |

---

### 6.4 `disk/`

#### `disk.Info()` / `disk.InfoFromRawData()` errors

| Error message fragment | Condition |
|---|---|
| `statfs failed: <os error>` | `unix.Statfs(path, &fs)` fails |
| `error parsing df: not 6 columns` | A `df` output line has wrong field count |
| `error parsing df: error parsing 'total blocks' field: <strconv error>` | Total-blocks column parse fails |
| `error parsing df: error parsing 'available blocks' field: <strconv error>` | Available-blocks column parse fails |
| `df did not return info for all dirs` | Fewer parsed entries than expected directories |

---

### 6.5 `pci/pci_devices.go`

#### `pci.Devices(friendlyNames)` errors

| Error message fragment | Condition |
|---|---|
| `getting lspci data: <exec error>` | `exec.Command("lspci", "-vmmnD").Output()` fails |
| `parsing lspci data: unexpected format for pci slot: <value>` | PCI slot has wrong format |
| `parsing lspci data: cannot parse pci bus number: <value>` | Bus-number hex parse fails |

Additional-properties errors are non-fatal, printed directly to stderr (no cobra prefix):

| Full stderr output | Condition |
|---|---|
| `Warning: failed to get additional properties: AMD: vRAM: <os error>` | AMD `/sys/bus/pci/devices/<slot>/mem_info_vram_total` unreadable |
| `Warning: failed to get additional properties: AMD: vRAM: <strconv error>` | AMD vRAM file content not a valid integer |
| `Warning: failed to get additional properties: AMD: gfx architecture: <os error>` | `/sys/class/kfd/kfd/topology/nodes` unreadable |
| `Warning: failed to get additional properties: AMD: gfx architecture: gfx_target_version not found for device with pci slot <slot>` | No KFD node matched the device |
| `Warning: failed to get additional properties: AMD: gfx architecture: gfx_target_version is invalid for this device` | Value is `"0"` |
| `Warning: failed to get additional properties: AMD: gfx architecture: gfx_target_version has an unexpected format: <value>` | Hex string shorter than 6 chars |
| `Warning: failed to get additional properties: AMD: gfx architecture: parsing major version from gfx_target_version: <strconv error>` | `strconv.Atoi` fails on chars 0–1 |
| `Warning: failed to get additional properties: AMD: gfx architecture: parsing minor version from gfx_target_version: <strconv error>` | `strconv.Atoi` fails on chars 2–3 |
| `Warning: failed to get additional properties: AMD: gfx architecture: parsing revision from gfx_target_version: <strconv error>` | `strconv.Atoi` fails on chars 4–5 |
| `Warning: failed to get additional properties: AMD: gfx architecture: unexpected format for gfx_target_version: <line>` | Line not 2 space-separated parts |
| `Warning: failed to get additional properties: NVIDIA: vRAM: nvidia-smi: <exec error>` | `nvidia-smi` fails, no stdout output |
| `Warning: failed to get additional properties: NVIDIA: vRAM: nvidia-smi: <exec error>: <stdout>` | `nvidia-smi` fails with stdout error message |
| `Warning: failed to get additional properties: NVIDIA: vRAM: <strconv error>` | vRAM value string not a valid integer |
| `Warning: failed to get additional properties: NVIDIA: compute capability: nvidia-smi: <exec error>` | Same patterns for compute-capability query |
| `Warning: failed to get additional properties: NVIDIA: compute capability: nvidia-smi: <exec error>: <stdout>` | Same |
| `Warning: failed to get additional properties: Intel: vRAM: <exec error>` | `clinfo --json` fails |
| `Warning: failed to get additional properties: Intel: vRAM: parsing clinfo json: <json error>` | JSON parse of clinfo output fails |
| `Warning: failed to get additional properties: Intel: vRAM: clinfo: no devices found` | `clinfo.Devices` is empty |
| `Warning: failed to get additional properties: Intel: vRAM: clinfo: no online devices found` | `clinfo.Devices[0].Online` is empty |

---

### 6.6 `pci/lspci.go`

#### `ParseLsPci()` errors

| Error message fragment | Condition |
|---|---|
| `unexpected format for pci slot: <value>` | Slot field not two `:` separators |
| `cannot parse pci bus number: <value>` | Bus-number hex string can't be parsed |

Friendly-name lookup failures are non-fatal, printed directly to stderr:

| Full stderr output | Condition |
|---|---|
| `Error looking up friendly name: opening pci database: <pcidb error>` | `pcidb.New()` fails |

---

### 6.7 `pci/nvidia/`

All nvidia errors surface as `Warning: failed to get additional properties: NVIDIA: ...` via [§6.5](#65-pcipci_devicesgo).

| Error chain (after `NVIDIA: `) | Condition |
|---|---|
| `vRAM: nvidia-smi: <exec error>` | `nvidia-smi` not found / fails, no stdout output |
| `vRAM: nvidia-smi: <exec error>: <stdout>` | `nvidia-smi` fails with stdout error message |
| `vRAM: <strconv error>` | vRAM value string not a valid integer |
| `compute capability: nvidia-smi: <exec error>` | Same patterns for compute-capability query |
| `compute capability: nvidia-smi: <exec error>: <stdout>` | Same |

---

### 6.8 `pci/amd/`

All AMD errors surface as `Warning: failed to get additional properties: AMD: ...` via [§6.5](#65-pcipci_devicesgo).

| Error chain (after `AMD: `) | Condition |
|---|---|
| `vRAM: <os error>` | `/sys/bus/pci/devices/<slot>/mem_info_vram_total` unreadable |
| `vRAM: <strconv error>` | File content not a valid integer |
| `gfx architecture: <os error>` | `/sys/class/kfd/kfd/topology/nodes` unreadable |
| `gfx architecture: gfx_target_version not found for device with pci slot <slot>` | No KFD node matched the device |
| `gfx architecture: gfx_target_version is invalid for this device` | Value is `"0"` |
| `gfx architecture: gfx_target_version has an unexpected format: <value>` | Hex string shorter than 6 chars |
| `gfx architecture: parsing major version from gfx_target_version: <strconv error>` | `strconv.Atoi` fails on chars 0–1 |
| `gfx architecture: parsing minor version from gfx_target_version: <strconv error>` | `strconv.Atoi` fails on chars 2–3 |
| `gfx architecture: parsing revision from gfx_target_version: <strconv error>` | `strconv.Atoi` fails on chars 4–5 |
| `gfx architecture: unexpected format for gfx_target_version: <line>` | Line not 2 space-separated parts |

---

### 6.9 `pci/intel/`

All Intel errors surface as `Warning: failed to get additional properties: Intel: ...` via [§6.5](#65-pcipci_devicesgo).

| Error chain (after `Intel: `) | Condition |
|---|---|
| `vRAM: <exec error>` | `clinfo --json` binary missing or command fails |
| `vRAM: parsing clinfo json: <json error>` | `json.Unmarshal` on clinfo output fails |
| `vRAM: clinfo: no devices found` | `clinfo.Devices` is empty |
| `vRAM: clinfo: no online devices found` | `clinfo.Devices[0].Online` is empty |

*(When vRAM lookup succeeds but no device PCI address matches `device.Slot`, `nil` is returned without error.)*

---

## 7. `pkg/snap_store/snap_store.go`

All errors from this package surface as `Warning: unable to get component sizes: <error>` — printed
directly by `use-engine` (to stderr) and `prune-cache` (to stdout), always including the error detail.

Full error chains from `ComponentSizes()`:

| Full error chain from `ComponentSizes` | Condition |
|---|---|
| `components sizes: SNAP_NAME is not set. Likely not inside a snap` | `$SNAP_NAME` env-var is empty |
| `components sizes: SNAP_REVISION is not set` | `$SNAP_REVISION` env-var is empty |
| `components sizes: not installed from store` | Revision starts with `"x"` (sideloaded) |
| `components sizes: parsing snap revision: <strconv error>` | `strconv.ParseInt` on revision string fails |
| `components sizes: getting snap info: creating new http request: <net error>` | `http.NewRequest` for snap info fails |
| `components sizes: getting snap info: HTTP request: <net error>` | Network error fetching snap info |
| `components sizes: getting snap info: HTTP status not OK: <code>` | Snap info response not 200 |
| `components sizes: getting snap info: json: <json error>` | JSON decode of snap info response fails |
| `components sizes: getting components: fetching refresh data from store: json: <json error>` | `json.Marshal` of refresh request body fails |
| `components sizes: getting components: fetching refresh data from store: new http request: <net error>` | `http.NewRequest` for refresh fails |
| `components sizes: getting components: fetching refresh data from store: HTTP request: <net error>` | Network error on refresh call |
| `components sizes: getting components: fetching refresh data from store: HTTP status not OK: <code>` | Refresh response not 200 |
| `components sizes: getting components: fetching refresh data from store: json: <json error>` | JSON decode of refresh response fails |
| `components sizes: getting components: store returned no refresh results` | `Results` slice is empty |
| `components sizes: getting components: no refresh results found for snap id <id>` | No result matches the snap ID |

---

## 8. `pkg/storage/`

### 8.1 `cache.go`

#### `SetActiveEngine(engine)` errors

| Error message fragment | Condition |
|---|---|
| `engine name cannot be empty` | `engine == ""` |
| `<snapctl.Set error>` | External snapctl error (unwrapped) |

#### `GetActiveEngine()` errors

| Error message fragment | Condition |
|---|---|
| `<snapctl.Get or json.Unmarshal error>` | Any non-ErrorNotFound storage error (unwrapped) |

---

### 8.2 `config.go`

#### `Config.Set(key, value, confType)` errors

| Error message fragment | Condition |
|---|---|
| `checking key: <snapctl error>` | `Config.Get(key)` fails during UserConfig validation |
| `unknown key` | Key not in schema (no existing value) |
| `<snapctl.Set error>` | `storage.Set` fails (unwrapped) |

#### `Config.SetDocument(key, value, confType)` errors

| Error message fragment | Condition |
|---|---|
| `<json.Marshal error>` | Value cannot be marshalled (unwrapped) |
| `<snapctl.Set error>` | `snapctl.Set(...).Document().Run()` fails (unwrapped) |

#### `Config.Get(key)` / `Config.GetAll()` errors

| Error message fragment | Condition |
|---|---|
| `<snapctl.Get or json.Unmarshal error>` | `loadConfigs` → `storage.Get` fails (unwrapped) |

#### `Config.Unset(key, confType)` errors

| Error message fragment | Condition |
|---|---|
| `<snapctl.Unset error>` | `snapctl.Unset(...).Run()` fails (unwrapped) |

---

### 8.3 `snapctl_storage.go`

The external boundary. All errors are raw errors from `github.com/canonical/go-snapctl` or stdlib:

| Method | External error source |
|---|---|
| `Set` | `snapctl.Set(...).Run()` |
| `SetDocument` | `json.Marshal` (stdlib) or `snapctl.Set(...).Document().Run()` |
| `Get` | `snapctl.Get(...).Run()` or `json.Unmarshal` (stdlib) |
| `Unset` | `snapctl.Unset(...).Run()` |

`ErrorNotFound` (`"not found"`) is returned (and immediately handled in `cache.go`) when `snapctl.Get` returns an empty string.

---

## 9. `pkg/utils/utils.go`

#### `StringToBytes(sizeString)` errors

| Error message fragment | Condition |
|---|---|
| `<strconv.ParseUint error>` | Numeric part of the size string is not a valid integer (unwrapped) |

#### `SubDirectories(dirPath)` errors

| Error message fragment | Condition |
|---|---|
| `failed to read directory: <os error>` | `os.ReadDir(dirPath)` fails |

---

## Cross-cutting Notes

### Non-fatal outputs (never cobra-prefixed, never returned as errors)

| Full output | Stream | Source | Condition |
|---|---|---|---|
| `Warning: unable to get component sizes: <error>` | stderr | `use-engine.go` | `snap_store.ComponentSizes()` fails (always includes error detail) |
| `Warning: unable to get component sizes: <error>` | stdout | `prune-cache.go` | `snap_store.ComponentSizes()` fails (always includes error detail) |
| `Warning: previously active engine "<name>" not found; skipping user configuration cleanup.` | stderr | `engine.go` | `ErrManifestNotFound` during unset with `unsetUserOverrides=true` |
| `Warning: failed to get additional properties: <vendor>: <error>` | stderr | `pci_devices.go` | Per-device, non-fatal; all AMD/NVIDIA/Intel tool errors |
| `Error looking up friendly name: <error>` | stderr | `lspci.go` | Per-device, non-fatal PCI database lookup failure |
| `No engines found.` | stderr | `list-engines.go` | Engine list is empty |
| `Note: "<key>" configuration field is deprecated!` | stderr | `get.go` | Deprecated key requested on a terminal |

### Sentinel errors (used with `errors.Is`)

| Sentinel | Package | Checked in |
|---|---|---|
| `engines.ErrManifestNotFound` | `pkg/engines` | `use-engine`, `prune-cache`, `run`, `engine.go` (`UnsetEngineConfig`) |
| `selector.ErrorNoCompatibleEngine` | `pkg/selector` | `use-engine` (`autoSelectEngine`), `debug/select` |
| `storage.ErrorNotFound` | `pkg/storage` | `cache.go` (`GetActiveEngine`) — handled internally, never surfaces to the user |
| `pci.ErrorVendorNotSupported` | `pkg/hardware_info/pci` | `pci_devices.go` (`addAdditionalProperties`) — silently ignored |

### Root-only commands (return `Error: permission denied, try again with sudo` immediately if not root)

`use-engine`, `set`, `prune-cache`


</details>









This PR can be reviewed by looking at, and commenting inline on the summary of possible error messages:
https://github.com/canonical/inference-snaps-cli/blob/e2bb729b259acdda00d8f21a8d7bfd8b6b29027c/errors-summary.md