### PR TITLE
Fix engine changed even if user aborts install request

### DIFF
--- a/cmd/cli/commands/use-engine.go
+++ b/cmd/cli/commands/use-engine.go
@@ -182,7 +182,7 @@ func (cmd *useEngineCommand) switchEngine(engineName string) error {
 		return fmt.Errorf("error setting new engine configurations: %v", err)
 	}
 
-	fmt.Printf("\nEngine changed to %q.\n", engineName)
+	fmt.Printf("Engine changed to %q.\n", engineName)
 
 	// TODO: get this from an env var instead (e.g. ENGINE_SERVICES=server,proxy)
 	serviceName := env.SnapInstanceName() + ".server"

--- a/cmd/cli/commands/use-engine.go
+++ b/cmd/cli/commands/use-engine.go
@@ -147,12 +147,12 @@ func (cmd *useEngineCommand) switchEngine(engineName string) error {
 		return fmt.Errorf("error loading engine manifest: %v", err)
 	}
 
-	componentsInstalled, err := cmd.installMissingComponents(engine)
+	cancelledByUser, err := cmd.installMissingComponents(engine)
 	if err != nil {
 		return fmt.Errorf("error installing missing components: %v", err)
 	}
 
-	if !componentsInstalled {
+	if cancelledByUser {
 		return nil
 	}
 
@@ -174,11 +174,6 @@ func (cmd *useEngineCommand) switchEngine(engineName string) error {
 		}
 	}
 
-	if componentsInstalled {
-		// Leave a blank line before continuing
-		fmt.Println()
-	}
-
 	if err = cmd.Cache.SetActiveEngine(engine.Name); err != nil {
 		return fmt.Errorf("error setting active engine: %v", err)
 	}
@@ -187,7 +182,7 @@ func (cmd *useEngineCommand) switchEngine(engineName string) error {
 		return fmt.Errorf("error setting new engine configurations: %v", err)
 	}
 
-	fmt.Printf("Engine changed to %q.\n", engineName)
+	fmt.Printf("\nEngine changed to %q.\n", engineName)
 
 	// TODO: get this from an env var instead (e.g. ENGINE_SERVICES=server,proxy)
 	serviceName := env.SnapInstanceName() + ".server"
@@ -306,13 +301,13 @@ func (cmd *useEngineCommand) fixActiveEngine() error {
 	return nil
 }
 
-func (cmd *useEngineCommand) installMissingComponents(engine *engines.Manifest) (installed bool, err error) {
+func (cmd *useEngineCommand) installMissingComponents(engine *engines.Manifest) (cancelledByUser bool, err error) {
 	missingComponents, err := cmd.missingComponents(engine.Components)
 	if err != nil {
 		return false, fmt.Errorf("error checking installed components: %v", err)
 	}
 	if len(missingComponents) == 0 {
-		return true, nil
+		return false, nil
 	}
 
 	// Look up component sizes from the snap store
@@ -337,7 +332,7 @@ func (cmd *useEngineCommand) installMissingComponents(engine *engines.Manifest) 
 		fmt.Println()
 		if !common.ConfirmationPrompt("Do you want to continue?") {
 			fmt.Println("Cancelled. No changes applied.")
-			return false, nil
+			return true, nil
 		}
 	}
 
@@ -351,7 +346,7 @@ func (cmd *useEngineCommand) installMissingComponents(engine *engines.Manifest) 
 		return false, fmt.Errorf("error installing components: %v", err)
 	}
 
-	return true, nil
+	return false, nil
 }
 
 func (cmd *useEngineCommand) verboseIncompatibilityReasons(report engines.CompatibilityReport) []string {

--- a/cmd/cli/commands/use-engine.go
+++ b/cmd/cli/commands/use-engine.go
@@ -336,7 +336,7 @@ func (cmd *useEngineCommand) installMissingComponents(engine *engines.Manifest) 
 	if !cmd.assumeYes && term.IsTerminal(int(os.Stdin.Fd())) {
 		fmt.Println()
 		if !common.ConfirmationPrompt("Do you want to continue?") {
-			fmt.Println("Exiting. No changes applied.")
+			fmt.Println("Cancelled. No changes applied.")
 			return false, nil
 		}
 	}

--- a/cmd/cli/commands/use-engine.go
+++ b/cmd/cli/commands/use-engine.go
@@ -152,6 +152,10 @@ func (cmd *useEngineCommand) switchEngine(engineName string) error {
 		return fmt.Errorf("error installing missing components: %v", err)
 	}
 
+	if !componentsInstalled {
+		return nil
+	}
+
 	activeEngineName, err := cmd.Cache.GetActiveEngine()
 	if err != nil {
 		return fmt.Errorf("error getting active engine: %v", err)
@@ -308,7 +312,7 @@ func (cmd *useEngineCommand) installMissingComponents(engine *engines.Manifest) 
 		return false, fmt.Errorf("error checking installed components: %v", err)
 	}
 	if len(missingComponents) == 0 {
-		return false, nil
+		return true, nil
 	}
 
 	// Look up component sizes from the snap store


### PR DESCRIPTION
fixes https://github.com/canonical/inference-snaps/issues/262

```
$ sudo gemma3 use-engine amd-gpu 

Engine changed to "amd-gpu".

Run "snap restart gemma3.server" to use the new engine.
```

```
$ sudo gemma3 prune-cache --engine=cpu
Removing components:
Warning: unable to get component sizes: error finding components of current snap: not installed from store
- llamacpp

Continue pruning "cpu" engine? [y/n] y
```

```
$ sudo gemma3 use-engine cpu
Warning: unable to get component sizes: error finding components of current snap: not installed from store
Need to install the following components:
- llamacpp

Do you want to continue? [y/n] n
Exiting. No changes applied.
```

```
$ sudo gemma3 list-engines
ENGINE            VENDOR             DESCRIPTION                         COMPAT
amd-gpu*          Canonical Ltd      Use ROCm for inference on AMD GPUs. devel 
cpu-xsmall        Canonical Ltd      Use CPU, very low footprints. Tex…  yes   
cpu               Canonical Ltd      Use CPU with a good balance betwe…  yes   
nvidia-gpu-arm64  Canonical Ltd      Use CUDA for inference on Nvidia …  no    
nvidia-gpu-amd64  Canonical Ltd      Use CUDA for inference on Nvidia …  no    
intel-gpu         Intel Corporation  Use Intel integrated and discrete…  no    
intel-cpu         Intel Corporation  Use Intel CPUs                      no
```