### PR TITLE
Use utils function to detect terminal

### DIFF
--- a/cmd/cli/commands/prune-cache.go
+++ b/cmd/cli/commands/prune-cache.go
@@ -14,7 +14,6 @@ import (
 	"github.com/canonical/inference-snaps-cli/pkg/snap_store"
 	"github.com/canonical/inference-snaps-cli/pkg/utils"
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 )
 
 type pruneCacheCommand struct {
@@ -222,7 +221,7 @@ func (cmd *pruneCacheCommand) printComponentsAndConfirm(componentsWithEngines ma
 		confirmationPromptSentence = fmt.Sprintf("Continue pruning [%v] engines?", strings.Join(engineList, ", "))
 	}
 
-	if term.IsTerminal(int(os.Stdin.Fd())) {
+	if utils.IsTerminalOutput() {
 		fmt.Println()
 		if !common.ConfirmationPrompt(confirmationPromptSentence) {
 			return false, nil

--- a/cmd/cli/commands/use-engine.go
+++ b/cmd/cli/commands/use-engine.go
@@ -15,7 +15,6 @@ import (
 	"github.com/canonical/inference-snaps-cli/pkg/snap_store"
 	"github.com/canonical/inference-snaps-cli/pkg/utils"
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 )
 
 type useEngineCommand struct {
@@ -329,7 +328,7 @@ func (cmd *useEngineCommand) installMissingComponents(engine *engines.Manifest) 
 	}
 
 	// Only ask for confirmation if it is an interactive terminal
-	if !cmd.assumeYes && term.IsTerminal(int(os.Stdin.Fd())) {
+	if !cmd.assumeYes && utils.IsTerminalOutput() {
 		fmt.Println()
 		if !common.ConfirmationPrompt("Do you want to continue?") {
 			fmt.Println("Exiting. No changes applied.")


### PR DESCRIPTION
We have a function in utils to detect if the current session is a terminal. It is however only used for `get` and the code is replicated in `prune-cache` and `use-engine`.