### PR TITLE
Only show component size warning in verbose mode

### DIFF
--- a/cmd/cli/commands/prune-cache.go
+++ b/cmd/cli/commands/prune-cache.go
@@ -190,7 +190,7 @@ func (cmd *pruneCacheCommand) printComponentsAndConfirm(componentsWithEngines ma
 		fmt.Println("Removing components:")
 
 		componentSizes, err := snap_store.ComponentSizes()
-		if err != nil {
+		if err != nil && cmd.Verbose {
 			fmt.Fprintf(os.Stderr, "Warning: unable to query component sizes: %v\n", err)
 		}
 

--- a/cmd/cli/commands/use-engine.go
+++ b/cmd/cli/commands/use-engine.go
@@ -311,10 +311,8 @@ func (cmd *useEngineCommand) installMissingComponents(engine *engines.Manifest) 
 		return false, nil
 	}
 
-	// Look up component sizes from the snap store
 	componentSizes, err := snap_store.ComponentSizes()
-	if err != nil {
-		// If component size lookup failed, continue but log the error
+	if err != nil && cmd.Verbose {
 		fmt.Fprintf(os.Stderr, "Warning: unable to query component sizes: %v\n", err)
 	}
 


### PR DESCRIPTION
Not being able to look up the component size is not critical, and a user should not even be notified if it failed. 

The warning can be very verbose, containing http error codes. Here we change the warning to only be shown in verbose mode.