### PR TITLE
Add strict checks in layout creation to avoid accidental file removal

### DIFF
--- a/cmd/cli/common/engine.go
+++ b/cmd/cli/common/engine.go
@@ -11,6 +11,7 @@ import (
 	"github.com/canonical/inference-snaps-cli/pkg/hardware_info"
 	"github.com/canonical/inference-snaps-cli/pkg/selector"
 	"github.com/canonical/inference-snaps-cli/pkg/storage"
+	"github.com/canonical/inference-snaps-cli/pkg/utils"
 	"gopkg.in/yaml.v3"
 )
 
@@ -116,7 +117,7 @@ func loadEngineEnvironmentFromSettingsCollection(settingsCollection []ComponentS
 
 		for layoutPath, layout := range settingsCollection[i].expandedLayout {
 			if layout.Symlink != "" {
-				if err := createTemporarySymlink(layout.Symlink, layoutPath); err != nil {
+				if err := utils.CreateTempSymlink(layout.Symlink, layoutPath); err != nil {
 					return fmt.Errorf("creating temporary symlink for component %q: %v", settings.componentName, err)
 				}
 			}
@@ -130,77 +131,12 @@ func loadEngineEnvironmentFromSettingsCollection(settingsCollection []ComponentS
 	return nil
 }
 
-func pathWithinTmp(path string) (bool, error) {
-	link, err := filepath.Abs(path)
-	if err != nil {
-		return false, fmt.Errorf("getting absolute path of %s: %v", path, err)
-	}
-	if strings.HasPrefix(link, "/tmp") {
-		return true, nil
-	}
-	return false, nil
-}
-
-func removeTemporarySymlink(path string) error {
-	info, err := os.Lstat(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil // If the file doesn't exist, consider it removed
-		}
-		return fmt.Errorf("stat %s: %v", path, err)
-	}
-
-	// Check if the path is within /tmp before removing
-	if withinTmp, err := pathWithinTmp(path); err != nil {
-		return fmt.Errorf("checking if path is within /tmp: %v", err)
-	} else if !withinTmp {
-		return fmt.Errorf("layout path outside of /tmp: %s", path)
-	}
-
-	// Only remove if it's a symlink to avoid accidentally deleting other files
-	if info.Mode()&os.ModeSymlink != 0 {
-		if err := os.Remove(path); err != nil {
-			return fmt.Errorf("removing file %s: %v", path, err)
-		}
-	} else {
-		fmt.Fprintf(os.Stderr, "Warning: expected %q to be a symlink but it is not; skipping removal.\n", path)
-	}
-
-	return nil
-}
-
-func createTemporarySymlink(target, link string) error {
-	// Reject any layout path that is outside of /tmp
-	if withinTmp, err := pathWithinTmp(link); err != nil {
-		return fmt.Errorf("checking if path is within /tmp: %v", err)
-	} else if !withinTmp {
-		return fmt.Errorf("layout path outside of /tmp: %s", link)
-	}
-
-	// Create directory tree for the link
-	if err := os.MkdirAll(filepath.Dir(link), 0755); err != nil {
-		return fmt.Errorf("creating directory for symlink %q: %v", link, err)
-	}
-
-	// Remove existing symlink if it exists
-	if err := removeTemporarySymlink(link); err != nil {
-		return fmt.Errorf("removing existing symlink at %q: %v", link, err)
-	}
-
-	// Create new symlink
-	if err := os.Symlink(target, link); err != nil {
-		return fmt.Errorf("creating symlink from %q to %q: %v", link, target, err)
-	}
-
-	return nil
-}
-
 func unloadEngineEnvironmentFromSettingsCollection(settingsCollection []ComponentSettings) error {
 
 	// remove the symlinks created for the engine components
 	for _, settings := range settingsCollection {
 		for layoutPath := range settings.expandedLayout {
-			if err := removeTemporarySymlink(layoutPath); err != nil {
+			if _, err := utils.RemoveTempSymlink(layoutPath); err != nil {
 				return fmt.Errorf("removing symlink %q: %v", layoutPath, err)
 			}
 		}

--- a/cmd/cli/common/engine.go
+++ b/cmd/cli/common/engine.go
@@ -80,6 +80,7 @@ func loadEngineEnvironmentFromSettingsCollection(settingsCollection []ComponentS
 	if !found {
 		return fmt.Errorf("SNAP_COMPONENTS env var not set")
 	}
+
 	for i, settings := range settingsCollection {
 		// Set component path env var for expansion
 		componentPath := filepath.Join(componentsDir, settings.componentName)
@@ -112,35 +113,85 @@ func loadEngineEnvironmentFromSettingsCollection(settingsCollection []ComponentS
 			}
 			settingsCollection[i].expandedLayout[os.ExpandEnv(k)] = ComponentLayout
 		}
+
 		for layoutPath, layout := range settingsCollection[i].expandedLayout {
 			if layout.Symlink != "" {
-				// Assigning variables for better readability
-				target := layout.Symlink
-				link := layoutPath
-				if !strings.HasPrefix(link, "/tmp") {
-					fmt.Fprintf(os.Stderr, "Warning: skipping symlink %q for component %q: path is not in /tmp\n", link, settings.componentName)
-					continue
-				}
-
-				// Ensure the parent directory for the link exists
-				if err := os.MkdirAll(filepath.Dir(link), 0755); err != nil {
-					return fmt.Errorf("error creating directory for symlink %q: %v", link, err)
-				}
-
-				// Remove existing file, symlink, or directory if it exists
-				if err := os.RemoveAll(link); err != nil {
-					return fmt.Errorf("error removing existing path %q: %v", link, err)
-				}
-				err := os.Symlink(target, link)
-				if err != nil {
-					return fmt.Errorf("error creating symlink from %q to %q: %v", link, target, err)
+				if err := createTemporarySymlink(layout.Symlink, layoutPath); err != nil {
+					return fmt.Errorf("creating temporary symlink for component %q: %v", settings.componentName, err)
 				}
 			}
 		}
 	}
+
 	if err := os.Unsetenv(componentEnv); err != nil {
 		return fmt.Errorf("error unsetting %q: %v", componentEnv, err)
 	}
+
+	return nil
+}
+
+func pathWithinTmp(path string) (bool, error) {
+	link, err := filepath.Abs(path)
+	if err != nil {
+		return false, fmt.Errorf("getting absolute path of %s: %v", path, err)
+	}
+	if strings.HasPrefix(link, "/tmp") {
+		return true, nil
+	}
+	return false, nil
+}
+
+func removeTemporarySymlink(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // If the file doesn't exist, consider it removed
+		}
+		return fmt.Errorf("stat %s: %v", path, err)
+	}
+
+	// Check if the path is within /tmp before removing
+	if withinTmp, err := pathWithinTmp(path); err != nil {
+		return fmt.Errorf("checking if path is within /tmp: %v", err)
+	} else if !withinTmp {
+		return fmt.Errorf("layout path outside of /tmp: %s", path)
+	}
+
+	// Only remove if it's a symlink to avoid accidentally deleting other files
+	if info.Mode()&os.ModeSymlink != 0 {
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("removing file %s: %v", path, err)
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "Warning: expected %q to be a symlink but it is not; skipping removal.\n", path)
+	}
+
+	return nil
+}
+
+func createTemporarySymlink(target, link string) error {
+	// Reject any layout path that is outside of /tmp
+	if withinTmp, err := pathWithinTmp(link); err != nil {
+		return fmt.Errorf("checking if path is within /tmp: %v", err)
+	} else if !withinTmp {
+		return fmt.Errorf("layout path outside of /tmp: %s", link)
+	}
+
+	// Create directory tree for the link
+	if err := os.MkdirAll(filepath.Dir(link), 0755); err != nil {
+		return fmt.Errorf("creating directory for symlink %q: %v", link, err)
+	}
+
+	// Remove existing symlink if it exists
+	if err := removeTemporarySymlink(link); err != nil {
+		return fmt.Errorf("removing existing symlink at %q: %v", link, err)
+	}
+
+	// Create new symlink
+	if err := os.Symlink(target, link); err != nil {
+		return fmt.Errorf("creating symlink from %q to %q: %v", link, target, err)
+	}
+
 	return nil
 }
 
@@ -149,7 +200,7 @@ func unloadEngineEnvironmentFromSettingsCollection(settingsCollection []Componen
 	// remove the symlinks created for the engine components
 	for _, settings := range settingsCollection {
 		for layoutPath := range settings.expandedLayout {
-			if err := os.RemoveAll(layoutPath); err != nil {
+			if err := removeTemporarySymlink(layoutPath); err != nil {
 				return fmt.Errorf("removing symlink %q: %v", layoutPath, err)
 			}
 		}
@@ -170,7 +221,6 @@ func LoadEngineEnvironment(ctx *Context) (func(), error) {
 		if err := unloadEngineEnvironmentFromSettingsCollection(settingsCollection); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to unload engine environment: %v\n", err)
 		}
-		return
 	}, err
 }
 

--- a/cmd/cli/common/engine_test.go
+++ b/cmd/cli/common/engine_test.go
@@ -12,7 +12,7 @@ import (
 func setupTestComponent(t *testing.T) (symlinkPath string) {
 	t.Helper()
 
-	componentsDir := t.TempDir()
+	componentsDir := t.TempDir() // always use temp dir to avoid unexpected file removal
 	t.Setenv("SNAP_COMPONENTS", componentsDir)
 
 	componentPath := filepath.Join(componentsDir, "dummy-component-2")
@@ -133,24 +133,24 @@ func TestSnapComponentsNotSet(t *testing.T) {
 	}
 }
 
-func TestCannotCreateDir(t *testing.T) {
-	_ = setupTestComponent(t)
+func TestRejectsLayoutOutsideTmp(t *testing.T) {
+	setupTestComponent(t)
 	settings := []ComponentSettings{
 		{
 			componentName: "dummy-component-2",
 			Layout: map[string]ComponentLayout{
-				"/NOT/EXISTENT": {
+				"/not/tmp": {
 					Symlink: "$SNAP_COMPONENTS/dummy-component-2/non_existent_file.txt",
 				},
-			},
-			Environment: []string{
-				"TEST_ENV_VAR=test",
 			},
 		},
 	}
 
 	err := loadEngineEnvironmentFromSettingsCollection(settings)
-	if err != nil && !strings.Contains(err.Error(), "error creating directory for symlink") {
-		t.Fatalf("expected skipping symlink creation due to path different from /tmp, got: %v", err)
+	if err == nil {
+		t.Fatal("expected error for layout path outside /tmp, got nil")
+	}
+	if !strings.Contains(err.Error(), "layout path outside of /tmp") {
+		t.Fatalf("expected outside /tmp error, got: %v", err)
 	}
 }

--- a/pkg/utils/symlink.go
+++ b/pkg/utils/symlink.go
@@ -1,0 +1,73 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func RemoveTempSymlink(path string) (success bool, err error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true, nil // nothing to remove, consider it a success
+		}
+		return false, fmt.Errorf("stat %s: %v", path, err)
+	}
+
+	// Check if the path is within /tmp before removing
+	if withinTmp, err := pathWithinTmp(path); err != nil {
+		return false, fmt.Errorf("checking if path is within /tmp: %v", err)
+	} else if !withinTmp {
+		return false, fmt.Errorf("layout path outside of /tmp: %s", path)
+	}
+
+	// Only remove if it's a symlink to avoid accidentally deleting other files
+	if info.Mode()&os.ModeSymlink != 0 {
+		if err := os.Remove(path); err != nil {
+			return false, fmt.Errorf("removing file %s: %v", path, err)
+		}
+	} else {
+		return false, fmt.Errorf("not a symlink: %s", path)
+	}
+
+	return true, nil // symlink removed successfully
+}
+
+func CreateTempSymlink(target, link string) error {
+	// Reject any layout path that is outside of /tmp
+	if withinTmp, err := pathWithinTmp(link); err != nil {
+		return fmt.Errorf("checking if path is within /tmp: %v", err)
+	} else if !withinTmp {
+		return fmt.Errorf("layout path outside of /tmp: %s", link)
+	}
+
+	// Create directory tree for the link
+	if err := os.MkdirAll(filepath.Dir(link), 0755); err != nil {
+		return fmt.Errorf("creating directory for symlink %q: %v", link, err)
+	}
+
+	// Remove existing symlink if it exists
+	if _, err := RemoveTempSymlink(link); err != nil {
+		return fmt.Errorf("removing existing symlink at %q: %v", link, err)
+	}
+
+	// Create new symlink
+	if err := os.Symlink(target, link); err != nil {
+		return fmt.Errorf("creating symlink from %q to %q: %v", link, target, err)
+	}
+
+	return nil
+}
+
+func pathWithinTmp(path string) (bool, error) {
+	link, err := filepath.Abs(path)
+	if err != nil {
+		return false, fmt.Errorf("getting absolute path of %s: %v", path, err)
+	}
+	if strings.HasPrefix(link, "/tmp") {
+		return true, nil
+	}
+	return false, nil
+}

--- a/pkg/utils/symlink_test.go
+++ b/pkg/utils/symlink_test.go
@@ -1,0 +1,200 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRemoveTempSymlinkSkipsRegularFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "not-a-symlink.txt")
+	if err := os.WriteFile(path, []byte("keep-me"), 0644); err != nil {
+		t.Fatalf("failed to create regular file: %v", err)
+	}
+
+	if _, err := RemoveTempSymlink(path); err == nil {
+		t.Fatalf("expected error removing regular file path, got nil")
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected regular file to remain, read failed: %v", err)
+	}
+	if string(content) != "keep-me" {
+		t.Fatalf("expected regular file content to stay intact, got %q", string(content))
+	}
+}
+
+func TestRemoveTempSymlinkRejectsOutsideTmp(t *testing.T) {
+	success, err := RemoveTempSymlink("/nonexistent-path-outside-tmp")
+	if err != nil {
+		t.Fatalf("unexpected error for non-existent path: %v", err)
+	}
+	if !success {
+		t.Fatalf("expected success for non-existent path, got false")
+	}
+}
+
+func TestCreateTempSymlinkBasic(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := filepath.Join(tmpDir, "target.txt")
+	link := filepath.Join(tmpDir, "link")
+
+	// Create target file
+	if err := os.WriteFile(target, []byte("content"), 0644); err != nil {
+		t.Fatalf("failed to create target file: %v", err)
+	}
+
+	// Create symlink
+	if err := CreateTempSymlink(target, link); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify symlink exists and points to target
+	linkTarget, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("failed to read symlink: %v", err)
+	}
+	if linkTarget != target {
+		t.Errorf("expected symlink target %q, got %q", target, linkTarget)
+	}
+
+	// Verify content is accessible through symlink
+	content, err := os.ReadFile(link)
+	if err != nil {
+		t.Fatalf("failed to read through symlink: %v", err)
+	}
+	if string(content) != "content" {
+		t.Errorf("expected content %q, got %q", "content", string(content))
+	}
+}
+
+func TestCreateTempSymlinkCreatesNestedDirs(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := filepath.Join(tmpDir, "target.txt")
+	link := filepath.Join(tmpDir, "nested", "dir", "structure", "link")
+
+	// Create target file
+	if err := os.WriteFile(target, []byte("data"), 0644); err != nil {
+		t.Fatalf("failed to create target file: %v", err)
+	}
+
+	// Create symlink with nested directories
+	if err := CreateTempSymlink(target, link); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify symlink exists
+	linkTarget, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("failed to read symlink: %v", err)
+	}
+	if linkTarget != target {
+		t.Errorf("expected symlink target %q, got %q", target, linkTarget)
+	}
+
+	// Verify all directories were created
+	info, err := os.Stat(filepath.Dir(link))
+	if err != nil {
+		t.Fatalf("directory structure not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("expected directory, got file")
+	}
+}
+
+func TestCreateTempSymlinkReplacesExisting(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldTarget := filepath.Join(tmpDir, "old-target.txt")
+	newTarget := filepath.Join(tmpDir, "new-target.txt")
+	link := filepath.Join(tmpDir, "link")
+
+	// Create target files
+	if err := os.WriteFile(oldTarget, []byte("old"), 0644); err != nil {
+		t.Fatalf("failed to create old target: %v", err)
+	}
+	if err := os.WriteFile(newTarget, []byte("new"), 0644); err != nil {
+		t.Fatalf("failed to create new target: %v", err)
+	}
+
+	// Create initial symlink
+	if err := CreateTempSymlink(oldTarget, link); err != nil {
+		t.Fatalf("failed to create initial symlink: %v", err)
+	}
+
+	// Verify initial symlink
+	linkTarget, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("failed to read initial symlink: %v", err)
+	}
+	if linkTarget != oldTarget {
+		t.Errorf("expected initial target %q, got %q", oldTarget, linkTarget)
+	}
+
+	// Replace symlink with new target
+	if err := CreateTempSymlink(newTarget, link); err != nil {
+		t.Fatalf("failed to replace symlink: %v", err)
+	}
+
+	// Verify symlink now points to new target
+	linkTarget, err = os.Readlink(link)
+	if err != nil {
+		t.Fatalf("failed to read replaced symlink: %v", err)
+	}
+	if linkTarget != newTarget {
+		t.Errorf("expected new target %q, got %q", newTarget, linkTarget)
+	}
+
+	// Verify content comes from new target
+	content, err := os.ReadFile(link)
+	if err != nil {
+		t.Fatalf("failed to read through symlink: %v", err)
+	}
+	if string(content) != "new" {
+		t.Errorf("expected content %q, got %q", "new", string(content))
+	}
+}
+
+func TestCreateTempSymlinkRejectsOutsideTmp(t *testing.T) {
+	target := "/some/file"
+	link := "./invalid-tmp-link"
+
+	err := CreateTempSymlink(target, link)
+	if err == nil {
+		t.Fatal("expected error for path outside /tmp, got nil")
+	}
+	if _, ok := err.(interface{ Error() string }); !ok {
+		t.Fatalf("expected error type, got: %T", err)
+	}
+}
+
+func TestCreateTempSymlinkDoesNotRemoveExistingRegularFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	target := filepath.Join(tmpDir, "target.txt")
+	link := filepath.Join(tmpDir, "link")
+
+	// Create target file
+	if err := os.WriteFile(target, []byte("target"), 0644); err != nil {
+		t.Fatalf("failed to create target: %v", err)
+	}
+
+	// Create a regular file at link location (not a symlink)
+	if err := os.WriteFile(link, []byte("regular"), 0644); err != nil {
+		t.Fatalf("failed to create regular file: %v", err)
+	}
+
+	// CreateTempSymlink should fail because we can't remove regular files
+	err := CreateTempSymlink(target, link)
+	if err == nil {
+		t.Fatal("expected error when trying to replace a regular file, got nil")
+	}
+
+	// Verify the regular file still exists unchanged
+	content, err := os.ReadFile(link)
+	if err != nil {
+		t.Fatalf("failed to read regular file: %v", err)
+	}
+	if string(content) != "regular" {
+		t.Errorf("expected regular file unchanged, got %q", string(content))
+	}
+}


### PR DESCRIPTION
Here is a fun story: I was trying to improve the following test which doesn't check nil error (directory created successfully outside temp). At some point I wanted to make `os.MkdirAll` fail by setting a smart path on line 142. It had to start with `/tmp` to bypass the prefix check but needed to fail when creating the directory, so I came up with: `/tmp/../`! In a matter of seconds, all my user-owned files were gone. I made this mistake as I didn't expect a test named "TestCannotCreateDir" end up making calls to `os.RemoveAll`. The good thing is that I really needed the disk space. 🙂

https://github.com/canonical/inference-snaps-cli/blob/212577a559c520655d814cd8f45781dd27f29c4d/cmd/cli/common/engine_test.go#L136-L156

Changes:
- Add strict checks in layout creation to avoid accidental file removal
  - Ensure that absolute path in tmp, not literal path
  - Remove only if target is a symlink
- Split symlink cleanup and creation to multiple functions with separate tests
- Move symlink handling to utils package