### PR TITLE
Default Y prompt, remove extra newline

### DIFF
--- a/cmd/cli/commands/prune-cache.go
+++ b/cmd/cli/commands/prune-cache.go
@@ -223,7 +223,8 @@ func (cmd *pruneCacheCommand) printComponentsAndConfirm(componentsWithEngines ma
 
 	if utils.IsTerminalOutput() {
 		fmt.Println()
-		if !common.ConfirmationPrompt(confirmationPromptSentence) {
+		if !common.PromptYN(confirmationPromptSentence, false) {
+			fmt.Println("Cancelled. No changes applied.")
 			return false, nil
 		}
 	}

--- a/cmd/cli/commands/use-engine.go
+++ b/cmd/cli/commands/use-engine.go
@@ -327,7 +327,7 @@ func (cmd *useEngineCommand) installMissingComponents(engine *engines.Manifest) 
 	// Only ask for confirmation if it is an interactive terminal
 	if !cmd.assumeYes && utils.IsTerminalOutput() {
 		fmt.Println()
-		if !common.ConfirmationPrompt("Do you want to continue?") {
+		if !common.PromptYN("Do you want to continue?", true) {
 			fmt.Println("Cancelled. No changes applied.")
 			return true, nil
 		}

--- a/cmd/cli/commands/webui.go
+++ b/cmd/cli/commands/webui.go
@@ -69,7 +69,7 @@ func (cmd *webUiCommand) run(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	if common.ConfirmationPromptEnter(fmt.Sprintf("Open %s in the default browser", url)) {
+	if common.ConfirmationPromptEnter(fmt.Sprintf("Opening %s in the default browser.", url)) {
 		// Use desktop portal to open URL in default browser
 		err = exec.Command("xdg-open", url).Start()
 		if err != nil {

--- a/cmd/cli/commands/webui.go
+++ b/cmd/cli/commands/webui.go
@@ -69,7 +69,8 @@ func (cmd *webUiCommand) run(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	if common.ConfirmationPromptEnter(fmt.Sprintf("Opening %s in the default browser.", url)) {
+	fmt.Printf("Web UI is available at %s\n", url)
+	if common.PromptlnEnter("open it in your browser") {
 		// Use desktop portal to open URL in default browser
 		err = exec.Command("xdg-open", url).Start()
 		if err != nil {

--- a/cmd/cli/commands/webui.go
+++ b/cmd/cli/commands/webui.go
@@ -1,9 +1,7 @@
 package commands
 
 import (
-	"bufio"
 	"fmt"
-	"os"
 	"os/exec"
 
 	"github.com/canonical/inference-snaps-cli/cmd/cli/common"
@@ -71,18 +69,12 @@ func (cmd *webUiCommand) run(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	// Print url and ask confirmation before opening
-	fmt.Printf("Press Enter to open %s in the default browser ...\n", url)
-	reader := bufio.NewReader(os.Stdin)
-	_, err = reader.ReadString('\n')
-	if err != nil {
-		return fmt.Errorf("waiting for Enter: %v", err)
-	}
-
-	// Use desktop portal to open URL in default browser
-	err = exec.Command("xdg-open", url).Start()
-	if err != nil {
-		return fmt.Errorf("xdg-open: %v", err)
+	if common.ConfirmationPromptEnter(fmt.Sprintf("Open %s in the default browser", url)) {
+		// Use desktop portal to open URL in default browser
+		err = exec.Command("xdg-open", url).Start()
+		if err != nil {
+			return fmt.Errorf("xdg-open: %v", err)
+		}
 	}
 
 	return nil

--- a/cmd/cli/common/prompt.go
+++ b/cmd/cli/common/prompt.go
@@ -39,20 +39,12 @@ func ConfirmationPrompt(prompt string) bool {
 func ConfirmationPromptEnter(prompt string) bool {
 	reader := bufio.NewReader(os.Stdin)
 
-	for {
-		fmt.Printf("%s [Enter] ", prompt)
+	fmt.Printf("%s Press [Enter] to continue... ", prompt)
 
-		input, err := reader.ReadString('\n')
-		if err != nil {
-			fmt.Printf("Error reading input: %v\n", err)
-			continue
-		}
-		input = strings.TrimSpace(input)
-
-		if input == "" {
-			return true
-		} else {
-			fmt.Println(`Invalid input. Please press "Enter" to continue or "Ctrl+C" to cancel.`)
-		}
+	_, err := reader.ReadString('\n')
+	if err != nil {
+		fmt.Printf("\nError reading input: %v\n", err)
+		return false
 	}
+	return true
 }

--- a/cmd/cli/common/prompt.go
+++ b/cmd/cli/common/prompt.go
@@ -7,13 +7,16 @@ import (
 	"strings"
 )
 
-// ConfirmationPrompt prompts the user and returns true for 'y', false for 'n'.
-// It defaults to true if the user presses Enter without a response.
-func ConfirmationPrompt(prompt string) bool {
+// Prompt prompts the user and returns true for 'y', false for 'n'.
+func PromptYN(prompt string, defaultResponse bool) bool {
 	reader := bufio.NewReader(os.Stdin)
 
 	for {
-		fmt.Printf("%s [Y/n] ", prompt) // default to yes
+		if defaultResponse == true {
+			fmt.Printf("%s [Y/n] ", prompt) // default is yes
+		} else {
+			fmt.Printf("%s [y/N] ", prompt) // default is no
+		}
 
 		input, err := reader.ReadString('\n')
 		if err != nil {
@@ -23,8 +26,8 @@ func ConfirmationPrompt(prompt string) bool {
 
 		input = strings.ToLower(strings.TrimSpace(input))
 		switch input {
-		case "": // default to yes on empty input
-			return true
+		case "": // default on empty input
+			return defaultResponse
 		case "Y", "y":
 			return true
 		case "N", "n":

--- a/cmd/cli/common/prompt.go
+++ b/cmd/cli/common/prompt.go
@@ -38,16 +38,21 @@ func PromptYN(prompt string, defaultResponse bool) bool {
 	}
 }
 
-// ConfirmationPromptEnter prompts the user for Enter
-func ConfirmationPromptEnter(prompt string) bool {
+// PromptEnterln prompts the user for Enter in a new line
+func PromptlnEnter(action string) bool {
 	reader := bufio.NewReader(os.Stdin)
 
-	fmt.Printf("%s Press [Enter] to continue... ", prompt)
+	fmt.Printf("Press [Enter] to %s, or [q] to abort. ", action)
 
-	_, err := reader.ReadString('\n')
+	input, err := reader.ReadString('\n')
 	if err != nil {
 		fmt.Printf("\nError reading input: %v\n", err)
 		return false
 	}
+
+	if strings.TrimSpace(input) == "q" {
+		return false
+	}
+
 	return true
 }

--- a/cmd/cli/common/prompt.go
+++ b/cmd/cli/common/prompt.go
@@ -38,19 +38,15 @@ func PromptYN(prompt string, defaultResponse bool) bool {
 	}
 }
 
-// PromptEnterln prompts the user for Enter in a new line
+// PromptlnEnter prompts the user for Enter in a new line
 func PromptlnEnter(action string) bool {
 	reader := bufio.NewReader(os.Stdin)
 
-	fmt.Printf("Press [Enter] to %s, or [q] to abort. ", action)
+	fmt.Printf("Press [Enter] to %s, or [Ctrl+C] to abort. ", action)
 
-	input, err := reader.ReadString('\n')
+	_, err := reader.ReadString('\n')
 	if err != nil {
 		fmt.Printf("\nError reading input: %v\n", err)
-		return false
-	}
-
-	if strings.TrimSpace(input) == "q" {
 		return false
 	}
 

--- a/cmd/cli/common/prompt.go
+++ b/cmd/cli/common/prompt.go
@@ -7,21 +7,52 @@ import (
 	"strings"
 )
 
-// ConfirmationPrompt prompts the user for a yes/no answer and returns true for 'y', false for 'n'.
+// ConfirmationPrompt prompts the user and returns true for 'y', false for 'n'.
+// It defaults to true if the user presses Enter without a response.
 func ConfirmationPrompt(prompt string) bool {
 	reader := bufio.NewReader(os.Stdin)
 
 	for {
-		fmt.Printf("%s [y/n] ", prompt)
-		input, _ := reader.ReadString('\n')
-		input = strings.ToLower(strings.TrimSpace(input))
+		fmt.Printf("%s [Y/n] ", prompt) // default to yes
 
-		if input == "y" || input == "yes" {
+		input, err := reader.ReadString('\n')
+		if err != nil {
+			fmt.Printf("Error reading input: %v\n", err)
+			continue
+		}
+
+		input = strings.ToLower(strings.TrimSpace(input))
+		switch input {
+		case "": // default to yes on empty input
 			return true
-		} else if input == "n" || input == "no" {
+		case "Y", "y":
+			return true
+		case "N", "n":
 			return false
-		} else {
+		default:
 			fmt.Println(`Invalid input. Please enter "y" or "n".`)
+		}
+	}
+}
+
+// ConfirmationPromptEnter prompts the user for Enter
+func ConfirmationPromptEnter(prompt string) bool {
+	reader := bufio.NewReader(os.Stdin)
+
+	for {
+		fmt.Printf("%s [Enter] ", prompt)
+
+		input, err := reader.ReadString('\n')
+		if err != nil {
+			fmt.Printf("Error reading input: %v\n", err)
+			continue
+		}
+		input = strings.TrimSpace(input)
+
+		if input == "" {
+			return true
+		} else {
+			fmt.Println(`Invalid input. Please press "Enter" to continue or "Ctrl+C" to cancel.`)
 		}
 	}
 }

--- a/cmd/cli/common/prompt_test.go
+++ b/cmd/cli/common/prompt_test.go
@@ -55,14 +55,5 @@ func ExamplePromptlnEnter() {
 	})
 
 	// Output:
-	// Press [Enter] to continue, or [q] to abort. -> true
-}
-
-func ExamplePromptlnEnter_abort() {
-	withStdin("q\n", func() {
-		printToStdout(PromptlnEnter("continue"))
-	})
-
-	// Output:
-	// Press [Enter] to continue, or [q] to abort. -> false
+	// Press [Enter] to continue, or [Ctrl+C] to abort. -> true
 }

--- a/cmd/cli/common/prompt_test.go
+++ b/cmd/cli/common/prompt_test.go
@@ -1,0 +1,68 @@
+package common
+
+import (
+	"fmt"
+	"os"
+)
+
+func withStdin(input string, fn func()) {
+	originalStdin := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+
+	if _, err := w.WriteString(input); err != nil {
+		panic(err)
+	}
+	_ = w.Close()
+
+	os.Stdin = r
+	defer func() {
+		os.Stdin = originalStdin
+		_ = r.Close()
+	}()
+
+	fn()
+}
+
+func printToStdout(a any) {
+	fmt.Printf("-> %v\n", a)
+}
+
+func ExamplePromptYN_defaultYes() {
+	withStdin("\n", func() {
+		printToStdout(PromptYN("Proceed?", true))
+	})
+
+	// Output:
+	// Proceed? [Y/n] -> true
+}
+
+func ExamplePromptYN_invalidThenNo() {
+	withStdin("maybe\nn\n", func() {
+		printToStdout(PromptYN("Proceed?", true))
+	})
+
+	// Output:
+	// Proceed? [Y/n] Invalid input. Please enter "y" or "n".
+	// Proceed? [Y/n] -> false
+}
+
+func ExamplePromptlnEnter() {
+	withStdin("\n", func() {
+		printToStdout(PromptlnEnter("continue"))
+	})
+
+	// Output:
+	// Press [Enter] to continue, or [q] to abort. -> true
+}
+
+func ExamplePromptlnEnter_abort() {
+	withStdin("q\n", func() {
+		printToStdout(PromptlnEnter("continue"))
+	})
+
+	// Output:
+	// Press [Enter] to continue, or [q] to abort. -> false
+}


### PR DESCRIPTION
Change confirmation to take "Y" by default:
```console
$ sudo gemma3 use-engine cpu-xsmall 
Need to install the following components:
- llamacpp (31.9MiB)
- model-270m-it-q4-0-gguf (225.1MiB)

Do you want to continue? [Y/n] Y

Installed llamacpp
Installed model-270m-it-q4-0-gguf
Engine changed to "cpu-xsmall".

Run "snap restart gemma3.server" to use the new engine.
```

Move "Enter" prompt handling to package. Remove extra newline after the prompt message. Change prompt message.

```console
$ gemma3 webui 
Open http://localhost:8081/ in the default browser [Enter]
```