### PR TITLE
Change default ports

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -14,11 +14,11 @@ exec 2> >(logger --stderr --priority error --tag=$tag)
 modelctl set --package verbose="false"
 
 # Main server http config
-modelctl set --package http.port="8080"
+modelctl set --package http.port="8322"
 modelctl set --package http.host="127.0.0.1"
 
 # Webui server config
-modelctl set --package webui.http.port="8081"
+modelctl set --package webui.http.port="8323"
 modelctl set --package webui.http.host="127.0.0.1"
 
 

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -13,7 +13,7 @@ exec 2> >(logger --stderr --priority error --tag=$tag)
 # Set default configurations for new options added after the initial release.
 # This ensures that default values are present in upgraded snaps.
 if ! modelctl get webui &> /dev/null; then
-    modelctl set --package webui.http.port="8081"
+    modelctl set --package webui.http.port="8323"
     modelctl set --package webui.http.host="127.0.0.1"
 fi
 


### PR DESCRIPTION
The snap is currently using port 8080 and 8081. This causes issues if one is also developing on Open WebUI or llama.cpp, as these two also use port 8080 as default. By changing this dev snap's default to a higher port, in the same range as other inference snaps, we avoid this conflict.