### PR TITLE
Make restart optional on set

### DIFF
--- a/cmd/cli/commands/set.go
+++ b/cmd/cli/commands/set.go
@@ -57,59 +57,69 @@ func (cmd *setCommand) run(_ *cobra.Command, args []string) error {
 }
 
 func (cmd *setCommand) setValue(keyValue string) error {
+	key, value, err := cmd.parseKeyValue(keyValue)
+	if err != nil {
+		return err
+	}
+
+	if cmd.packageConfig {
+		if err := cmd.Config.Set(key, value, storage.PackageConfig); err != nil {
+			return fmt.Errorf("setting %q to %q: %v", key, value, err)
+		}
+	} else if cmd.engineConfig {
+		if err := cmd.Config.Set(key, value, storage.EngineConfig); err != nil {
+			return fmt.Errorf("setting %q to %q: %v", key, value, err)
+		}
+	}
+
+	return cmd.setUserConfig(key, value)
+}
+
+func (cmd *setCommand) parseKeyValue(keyValue string) (key, value string, err error) {
+	if keyValue == "" {
+		return "", "", fmt.Errorf("expected key=value, got %q", keyValue)
+	}
+
 	if keyValue[0] == '=' {
-		return fmt.Errorf("key must not start with an equal sign")
+		return "", "", fmt.Errorf("key must not start with an equal sign")
 	}
 
 	// The value itself can contain an equal sign, so we split only on the first occurrence
 	parts := strings.SplitN(keyValue, "=", 2)
 	if len(parts) != 2 {
-		return fmt.Errorf("expected key=value, got %q", keyValue)
+		return "", "", fmt.Errorf("expected key=value, got %q", keyValue)
 	}
-	key, value := parts[0], parts[1]
+	return parts[0], parts[1], nil
+}
 
-	var err error
-	if cmd.packageConfig {
-		err = cmd.Config.Set(key, value, storage.PackageConfig)
-	} else if cmd.engineConfig {
-		err = cmd.Config.Set(key, value, storage.EngineConfig)
-	} else { // configurations set by the user
+// setUserConfig overrides existing package and engine configurations.
+// Unknown keys are rejected, except for passthrough keys.
+func (cmd *setCommand) setUserConfig(key, value string) error {
 
-		// User configs are overrides, reject unknown keys
-		currValMap, err := cmd.Config.Get(key)
-		if err != nil {
-			return fmt.Errorf("checking existing keys: %s", err)
-		}
-		currVal, found := currValMap[key]
-		if !found && !strings.HasPrefix(key, "passthrough.") {
-			return fmt.Errorf("unknown key: %q", key)
-		}
-
-		if fmt.Sprint(currVal) == value {
-			return nil // no change needed
-		}
-
-		if !cmd.noRestart {
-			msg := fmt.Sprintf("Apply changes and restart %s?", cmd.Snap.InstanceName())
-			if !(cmd.assumeYes || common.PromptYN(msg, true)) {
-				fmt.Println("Cancelled. Changes not applied.")
-				return nil
-			}
-		}
-
-		err = cmd.Config.Set(key, value, storage.UserConfig)
-	}
+	currValMap, err := cmd.Config.Get(key)
 	if err != nil {
+		return fmt.Errorf("checking existing keys: %s", err)
+	}
+	currVal, found := currValMap[key]
+	if !found && !strings.HasPrefix(key, "passthrough.") {
+		return fmt.Errorf("unknown key: %q", key)
+	}
+
+	if fmt.Sprint(currVal) == value {
+		return nil // no change needed
+	}
+
+	if err := cmd.Config.Set(key, value, storage.UserConfig); err != nil {
 		return fmt.Errorf("setting %q to %q: %v", key, value, err)
 	}
 
-	if cmd.noRestart {
-		fmt.Println(common.SuggestRestartToApplyChanges())
-	} else {
-		if err := cmd.Snap.Restart(); err != nil {
-			return fmt.Errorf("restarting snap: %v", err)
+	if !cmd.noRestart {
+		msg := fmt.Sprintf("Restart %s to apply the changes?", cmd.Snap.InstanceName())
+		if cmd.assumeYes || common.PromptYN(msg, true) {
+			if err := cmd.Snap.Restart(); err != nil {
+				return fmt.Errorf("restarting snap: %v", err)
+			}
 		}
 	}
-
 	return nil
 }

--- a/cmd/cli/commands/set_test.go
+++ b/cmd/cli/commands/set_test.go
@@ -10,19 +10,19 @@ import (
 	"github.com/canonical/inference-snaps-cli/pkg/storage"
 )
 
-func TestSetValueValidation(t *testing.T) {
-	config := storage.NewMockConfig(map[string]any{})
-	cmd := setCommand{
-		noRestart: true,
-		Context: &common.Context{
-			Config: config,
-			Snap:   snap.Mock(),
-		},
-	}
+func TestParseKeyValue(t *testing.T) {
+	cmd := setCommand{}
+
 	tests := map[string]struct {
 		input       string
+		wantKey     string
+		wantValue   string
 		errContains string
 	}{
+		"empty input": {
+			input:       "",
+			errContains: "expected key=value",
+		},
 		"missing equal sign": {
 			input:       "model",
 			errContains: "expected key=value",
@@ -31,16 +31,37 @@ func TestSetValueValidation(t *testing.T) {
 			input:       "=value",
 			errContains: "key must not start with an equal sign",
 		},
+		"simple pair": {
+			input:     "model=llama",
+			wantKey:   "model",
+			wantValue: "llama",
+		},
+		"value keeps equal signs": {
+			input:     "api.endpoint=https://example.com?a=b",
+			wantKey:   "api.endpoint",
+			wantValue: "https://example.com?a=b",
+		},
 	}
 
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
-			err := cmd.setValue(testCase.input)
-			if err == nil {
-				t.Fatalf("expected error containing %q, got nil", testCase.errContains)
+			gotKey, gotValue, err := cmd.parseKeyValue(testCase.input)
+			if testCase.errContains != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", testCase.errContains)
+				}
+				if !strings.Contains(err.Error(), testCase.errContains) {
+					t.Fatalf("expected error containing %q, got %q", testCase.errContains, err.Error())
+				}
+				return
 			}
-			if !strings.Contains(err.Error(), testCase.errContains) {
-				t.Fatalf("expected error containing %q, got %q", testCase.errContains, err.Error())
+
+			if err != nil {
+				t.Fatalf("parseKeyValue returned an unexpected error: %v", err)
+			}
+
+			if gotKey != testCase.wantKey || gotValue != testCase.wantValue {
+				t.Fatalf("expected (%q, %q), got (%q, %q)", testCase.wantKey, testCase.wantValue, gotKey, gotValue)
 			}
 		})
 	}
@@ -56,7 +77,7 @@ func TestSetValueSuccessForUserConfig(t *testing.T) {
 		},
 	}
 
-	err := cmd.setValue("api.endpoint=https://example.com?x=1=y")
+	err := cmd.setValue("api.endpoint=https://new.example.com")
 	if err != nil {
 		t.Fatalf("setValue returned an unexpected error: %v", err)
 	}
@@ -66,8 +87,28 @@ func TestSetValueSuccessForUserConfig(t *testing.T) {
 		t.Fatalf("Get returned an unexpected error: %v", err)
 	}
 
-	if value, found := values["api.endpoint"]; !found || value != "https://example.com?x=1=y" {
+	if value, found := values["api.endpoint"]; !found || value != "https://new.example.com" {
 		t.Fatalf("expected api.endpoint to be set to full value, got %#v", values)
+	}
+}
+
+func TestSetValueRejectsUnknownKeys(t *testing.T) {
+	config := storage.NewMockConfig(map[string]any{})
+	cmd := setCommand{
+		noRestart: true,
+		Context: &common.Context{
+			Config: config,
+			Snap:   snap.Mock(),
+		},
+	}
+
+	err := cmd.setValue("api.endpoint=https://example.com")
+	if err == nil {
+		t.Fatal("expected error for unknown key, got nil")
+	} else {
+		if !strings.Contains(err.Error(), "unknown key") {
+			t.Fatalf("expected unknown key error, got: %s", err)
+		}
 	}
 }
 
@@ -87,7 +128,7 @@ func TestSetNoPromptIfValueNotChanged(t *testing.T) {
 	}
 }
 
-func ExampleSet_noRestartSuggestsRestart() {
+func ExampleSet_assumeYesRestartServices() {
 	if err := os.Setenv("SNAP_INSTANCE_NAME", "example-snap"); err != nil {
 		panic(err)
 	}
@@ -97,7 +138,7 @@ func ExampleSet_noRestartSuggestsRestart() {
 
 	config := storage.NewMockConfig(map[string]any{"api.endpoint": "https://old.example.com"})
 	cmd := setCommand{
-		noRestart: true,
+		assumeYes: true,
 		Context: &common.Context{
 			Config: config,
 			Snap:   snap.Mock(),
@@ -109,5 +150,5 @@ func ExampleSet_noRestartSuggestsRestart() {
 	}
 
 	// Output:
-	// Run "snap restart example-snap" to apply the changes.
+	// [mock] Restarting all services
 }

--- a/cmd/cli/common/suggestions.go
+++ b/cmd/cli/common/suggestions.go
@@ -66,12 +66,3 @@ func SuggestEngineInfo() string {
 
 	return fmt.Sprintf("Use \"%v show-engine <engine>\" for more information about an engine.", instanceName)
 }
-
-func SuggestRestartToApplyChanges() string {
-	instanceName := env.SnapInstanceName()
-	if instanceName == "" { // not a snap
-		instanceName = "<snap-instance-name>"
-	}
-
-	return fmt.Sprintf("Run \"snap restart %s\" to apply the changes.", instanceName)
-}


### PR DESCRIPTION
The mandatory restart implemented by #331 is awkward in practice, as it prevents command chaining without restarts when the --no-restart is not set. This was by design, nevertheless, it does not feel natural to revert configurations (the primary intent of the command) just because a restart isn't wanted at that point. I ran into it when trying to replicate the steps given [here](https://github.com/canonical/inference-snaps-cli/pull/328#pullrequestreview-4128964176).

I've also done some refactoring in the set command for better testability. The returned errors from the two new methods are passed as is (no context added to the error chains). I consider this a reasonable deviation for when calling sibling methods.

```console
$ stack-utils get
http.host: 127.0.0.1
http.port: 8322
verbose: 1
webui.http.host: 127.0.0.1
webui.http.port: 8323
$ stack-utils set x=1
Error: permission denied, try again with sudo
$ sudo stack-utils set x=1
Error: key "x" is not found
$ sudo stack-utils set verbose=1
$ sudo stack-utils set verbose=2
Restart stack-utils to apply the changes? [Y/n] n
$ sudo stack-utils set verbose=2
$ sudo stack-utils set verbose=3
Restart stack-utils to apply the changes? [Y/n] y
```
