### PR TITLE
Add canonical/inference-snaps-dev as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "dev"]
+	path = dev
+	url = https://github.com/canonical/inference-snaps-dev
+	branch = v2


### PR DESCRIPTION
The scripts work except for the following command, which fails because engine manifests are at a different path. This can be fixed by falling back to the test_data directory.

```
$ ./dev/install.sh --engine=intel-cpu
Unknown engine: intel-cpu
```