### PR TITLE
Make run and serve-webui always wait for component

### DIFF
--- a/cmd/cli/commands/run.go
+++ b/cmd/cli/commands/run.go
@@ -40,6 +40,7 @@ func Run(ctx *common.Context) *cobra.Command {
 
 	// flags
 	cobraCmd.Flags().BoolVar(&cmd.waitForComponents, "wait-for-components", false, "wait for engine components to be installed before running")
+	cobraCmd.Flags().MarkDeprecated("wait-for-components", "\"run\" always waits for components.")
 
 	return cobraCmd
 }
@@ -48,10 +49,10 @@ func (cmd *runCommand) run(_ *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("unexpected number of arguments, expected at least 1 got %d", len(args))
 	}
-	if cmd.waitForComponents {
-		if err := common.WaitForComponents(cmd.Context); err != nil {
-			return fmt.Errorf("waiting for component: %s", err)
-		}
+
+	// Components are required for loading the engine environment
+	if err := common.WaitForComponents(cmd.Context); err != nil {
+		return fmt.Errorf("waiting for component: %s", err)
 	}
 
 	clean, err := common.LoadEngineEnvironment(cmd.Context)

--- a/cmd/cli/commands/serve-webui.go
+++ b/cmd/cli/commands/serve-webui.go
@@ -44,6 +44,11 @@ func ServeWebUi(ctx *common.Context) *cobra.Command {
 func (cmd *serveWebUiCommand) serveWebUi(_ *cobra.Command, args []string) error {
 	staticDir := args[0]
 
+	// Components are required to get the OpenAI endpoint
+	if err := common.WaitForComponents(cmd.Context); err != nil {
+		return fmt.Errorf("waiting for component: %s", err)
+	}
+
 	baseURL, err := common.OpenAiEndpoint(cmd.Context)
 	if err != nil {
 		return fmt.Errorf("getting OpenAI base URL: %v", err)

--- a/cmd/cli/commands/use-engine.go
+++ b/cmd/cli/commands/use-engine.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/canonical/go-snapctl"
-	"github.com/canonical/go-snapctl/env"
 	"github.com/canonical/inference-snaps-cli/cmd/cli/common"
 	"github.com/canonical/inference-snaps-cli/pkg/engines"
 	"github.com/canonical/inference-snaps-cli/pkg/selector"
@@ -183,14 +182,11 @@ func (cmd *useEngineCommand) switchEngine(engineName string) error {
 
 	fmt.Printf("Engine changed to %q.\n", engineName)
 
-	// TODO: get this from an env var instead (e.g. ENGINE_SERVICES=server,proxy)
-	serviceName := env.SnapInstanceName() + ".server"
-
 	// Currently we cannot reliably determine if the service is active to automatically restart it
 	// See https://bugs.launchpad.net/snapd/+bug/2137543
 	//
 	// Ask the user to restart the service manually
-	fmt.Printf("\nRun \"snap restart %s\" to use the new engine.\n", serviceName)
+	fmt.Printf("\nRun \"snap restart %s\" to use the new engine.\n", cmd.Snap.InstanceName())
 
 	return nil
 }

--- a/cmd/cli/commands/use-engine.go
+++ b/cmd/cli/commands/use-engine.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/canonical/go-snapctl"
+	"github.com/canonical/go-snapctl/env"
 	"github.com/canonical/inference-snaps-cli/cmd/cli/common"
 	"github.com/canonical/inference-snaps-cli/pkg/engines"
 	"github.com/canonical/inference-snaps-cli/pkg/selector"
@@ -182,11 +183,14 @@ func (cmd *useEngineCommand) switchEngine(engineName string) error {
 
 	fmt.Printf("Engine changed to %q.\n", engineName)
 
+	// TODO: get this from an env var instead (e.g. ENGINE_SERVICES=server,proxy)
+	serviceName := env.SnapInstanceName() + ".server"
+
 	// Currently we cannot reliably determine if the service is active to automatically restart it
 	// See https://bugs.launchpad.net/snapd/+bug/2137543
 	//
 	// Ask the user to restart the service manually
-	fmt.Printf("\nRun \"snap restart %s\" to use the new engine.\n", cmd.Snap.InstanceName())
+	fmt.Printf("\nRun \"snap restart %s\" to use the new engine.\n", serviceName)
 
 	return nil
 }


### PR DESCRIPTION
The `run` command waits for components only when the `--wait-for-components` is set. This has been deprecated in favor of always waiting for components. This is because in practice, the run command fails to operate without the components. It makes more sense to have it wait by default, as the sole purpose of the command is to run a program after applying the engine's environment. The binaries and definitions that `run` uses come from the components.

Make `serve-webui` wait for components. This is required in order to prepare the OpenAI endpoint on startup for serving /config. In the future, this requirement can be dropped by making the server construct config on demand.