### PR TITLE
Add unset command

### DIFF
--- a/cmd/cli/commands/get.go
+++ b/cmd/cli/commands/get.go
@@ -43,7 +43,7 @@ func (cmd *getCommand) getValue(key string) error {
 	}
 
 	if len(value) == 0 {
-		return fmt.Errorf("%s", common.SuggestKeyNotFound(key))
+		return fmt.Errorf("Key %q is not found\n\n%s", key, common.SuggestKeyNotFound(key))
 	}
 
 	if len(value) == 1 {

--- a/cmd/cli/commands/get.go
+++ b/cmd/cli/commands/get.go
@@ -43,7 +43,7 @@ func (cmd *getCommand) getValue(key string) error {
 	}
 
 	if len(value) == 0 {
-		return fmt.Errorf("Key %q is not found\n\n%s", key, common.SuggestKeyNotFound(key))
+		return fmt.Errorf("key %q is not found\n\n%s", key, common.SuggestKeyNotFound(key))
 	}
 
 	if len(value) == 1 {

--- a/cmd/cli/commands/get.go
+++ b/cmd/cli/commands/get.go
@@ -43,7 +43,7 @@ func (cmd *getCommand) getValue(key string) error {
 	}
 
 	if len(value) == 0 {
-		return fmt.Errorf("key %q is not found\n\nUse \"%s get\" to view available keys", key, cmd.Snap.InstanceName())
+		return fmt.Errorf("%s", common.SuggestKeyNotFound(key))
 	}
 
 	if len(value) == 1 {

--- a/cmd/cli/commands/get.go
+++ b/cmd/cli/commands/get.go
@@ -43,7 +43,7 @@ func (cmd *getCommand) getValue(key string) error {
 	}
 
 	if len(value) == 0 {
-		return fmt.Errorf("no value set for key %q", key)
+		return fmt.Errorf("key %q is not found\n\nUse \"%s get\" to view available keys", key, cmd.Snap.InstanceName())
 	}
 
 	if len(value) == 1 {

--- a/cmd/cli/commands/run_test.go
+++ b/cmd/cli/commands/run_test.go
@@ -36,11 +36,9 @@ func TestGetEnvVarsFromPassthroughConfigs(t *testing.T) {
 
 func TestProcessPassthroughConfigs(t *testing.T) {
 	mockConfig := storage.NewMockConfig()
-	mockConfig.SetAll(map[string]any{
-		"passthrough.environment.my-key": "value",
-		"passthrough.environment.other":  123,
-		"passthrough.not-environment":    "ignored",
-	}, storage.UserConfig)
+	mockConfig.Set("passthrough.environment.my-key", "value", storage.UserConfig)
+	mockConfig.Set("passthrough.environment.other", "123", storage.UserConfig)
+	mockConfig.Set("passthrough.not-environment", "ignored", storage.UserConfig)
 	cmd := runCommand{
 		Context: &common.Context{
 			Config: mockConfig,

--- a/cmd/cli/commands/run_test.go
+++ b/cmd/cli/commands/run_test.go
@@ -38,9 +38,9 @@ func TestProcessPassthroughConfigs(t *testing.T) {
 	cmd := runCommand{
 		Context: &common.Context{
 			Config: storage.NewMockConfig(map[string]any{
-				"passthrough.environment.my-key": "value",
-				"passthrough.environment.other":  123,
-				"passthrough.not-environment":    "ignored",
+				"user.passthrough.environment.my-key": "value",
+				"user.passthrough.environment.other":  123,
+				"user.passthrough.not-environment":    "ignored",
 			}),
 		},
 	}

--- a/cmd/cli/commands/run_test.go
+++ b/cmd/cli/commands/run_test.go
@@ -35,13 +35,15 @@ func TestGetEnvVarsFromPassthroughConfigs(t *testing.T) {
 }
 
 func TestProcessPassthroughConfigs(t *testing.T) {
+	mockConfig := storage.NewMockConfig()
+	mockConfig.SetAll(map[string]any{
+		"passthrough.environment.my-key": "value",
+		"passthrough.environment.other":  123,
+		"passthrough.not-environment":    "ignored",
+	}, storage.UserConfig)
 	cmd := runCommand{
 		Context: &common.Context{
-			Config: storage.NewMockConfig(map[string]any{
-				"user.passthrough.environment.my-key": "value",
-				"user.passthrough.environment.other":  123,
-				"user.passthrough.not-environment":    "ignored",
-			}),
+			Config: mockConfig,
 		},
 	}
 

--- a/cmd/cli/commands/set.go
+++ b/cmd/cli/commands/set.go
@@ -102,7 +102,7 @@ func (cmd *setCommand) setUserConfig(key, value string) error {
 	}
 	currVal, found := currValMap[key]
 	if !found && !strings.HasPrefix(key, "passthrough.") {
-		return fmt.Errorf("unknown key: %q", key)
+		return fmt.Errorf("key %q is not found\n\nUse \"%s get\" to view available keys", key, cmd.Snap.InstanceName())
 	}
 
 	if fmt.Sprint(currVal) == value {

--- a/cmd/cli/commands/set.go
+++ b/cmd/cli/commands/set.go
@@ -102,7 +102,7 @@ func (cmd *setCommand) setUserConfig(key, value string) error {
 	}
 	currVal, found := currValMap[key]
 	if !found && !strings.HasPrefix(key, "passthrough.") {
-		return fmt.Errorf("%s", common.SuggestKeyNotFound(key))
+		return fmt.Errorf("Key %q is not found\n\n%s", key, common.SuggestKeyNotFound(key))
 	}
 
 	if fmt.Sprint(currVal) == value {

--- a/cmd/cli/commands/set.go
+++ b/cmd/cli/commands/set.go
@@ -102,7 +102,7 @@ func (cmd *setCommand) setUserConfig(key, value string) error {
 	}
 	currVal, found := currValMap[key]
 	if !found && !strings.HasPrefix(key, "passthrough.") {
-		return fmt.Errorf("Key %q is not found\n\n%s", key, common.SuggestKeyNotFound(key))
+		return fmt.Errorf("key %q is not found\n\n%s", key, common.SuggestKeyNotFound(key))
 	}
 
 	if fmt.Sprint(currVal) == value {

--- a/cmd/cli/commands/set.go
+++ b/cmd/cli/commands/set.go
@@ -102,7 +102,7 @@ func (cmd *setCommand) setUserConfig(key, value string) error {
 	}
 	currVal, found := currValMap[key]
 	if !found && !strings.HasPrefix(key, "passthrough.") {
-		return fmt.Errorf("key %q is not found\n\nUse \"%s get\" to view available keys", key, cmd.Snap.InstanceName())
+		return fmt.Errorf("%s", common.SuggestKeyNotFound(key))
 	}
 
 	if fmt.Sprint(currVal) == value {

--- a/cmd/cli/commands/set_test.go
+++ b/cmd/cli/commands/set_test.go
@@ -68,11 +68,14 @@ func TestParseKeyValue(t *testing.T) {
 }
 
 func TestSetValueSuccessForUserConfig(t *testing.T) {
-	config := storage.NewMockConfig(map[string]any{"user.api.endpoint": "https://old.example.com"})
+	mockConfig := storage.NewMockConfig()
+	mockConfig.SetAll(map[string]any{
+		"api.endpoint": "https://old.example.com",
+	}, storage.UserConfig)
 	cmd := setCommand{
 		noRestart: true,
 		Context: &common.Context{
-			Config: config,
+			Config: mockConfig,
 			Snap:   snap.Mock(),
 		},
 	}
@@ -82,7 +85,7 @@ func TestSetValueSuccessForUserConfig(t *testing.T) {
 		t.Fatalf("setValue returned an unexpected error: %v", err)
 	}
 
-	values, err := config.Get("user.api.endpoint")
+	values, err := mockConfig.Get("user.api.endpoint")
 	if err != nil {
 		t.Fatalf("Get returned an unexpected error: %v", err)
 	}
@@ -93,7 +96,7 @@ func TestSetValueSuccessForUserConfig(t *testing.T) {
 }
 
 func TestSetValueRejectsUnknownKeys(t *testing.T) {
-	config := storage.NewMockConfig(map[string]any{})
+	config := storage.NewMockConfig()
 	cmd := setCommand{
 		noRestart: true,
 		Context: &common.Context{
@@ -113,7 +116,10 @@ func TestSetValueRejectsUnknownKeys(t *testing.T) {
 }
 
 func TestSetNoPromptIfValueNotChanged(t *testing.T) {
-	config := storage.NewMockConfig(map[string]any{"user.api.port": 8080})
+	config := storage.NewMockConfig()
+	config.SetAll(map[string]any{
+		"api.port": "8080",
+	}, storage.UserConfig)
 	cmd := setCommand{
 		assumeYes: false, // should not prompt since no change is needed
 		Context: &common.Context{
@@ -136,7 +142,10 @@ func ExampleSet_assumeYesRestartServices() {
 		_ = os.Unsetenv("SNAP_INSTANCE_NAME")
 	}()
 
-	config := storage.NewMockConfig(map[string]any{"api.endpoint": "https://old.example.com"})
+	config := storage.NewMockConfig()
+	config.SetAll(map[string]any{
+		"api.endpoint": "https://old.example.com",
+	}, storage.UserConfig)
 	cmd := setCommand{
 		assumeYes: true,
 		Context: &common.Context{

--- a/cmd/cli/commands/set_test.go
+++ b/cmd/cli/commands/set_test.go
@@ -83,13 +83,13 @@ func TestSetValueSuccessForUserConfig(t *testing.T) {
 		t.Fatalf("setValue returned an unexpected error: %v", err)
 	}
 
-	values, err := mockConfig.Get("user.api.endpoint")
+	values, err := mockConfig.Get("api.endpoint")
 	if err != nil {
 		t.Fatalf("Get returned an unexpected error: %v", err)
 	}
 
-	if value, found := values["user.api.endpoint"]; !found || value != "https://new.example.com" {
-		t.Fatalf("expected user.api.endpoint to be set to full value, got %#v", values)
+	if value, found := values["api.endpoint"]; !found || value != "https://new.example.com" {
+		t.Fatalf("expected api.endpoint in user config to be set to full value, got %#v", values)
 	}
 }
 

--- a/cmd/cli/commands/set_test.go
+++ b/cmd/cli/commands/set_test.go
@@ -115,7 +115,7 @@ func TestSetValueRejectsUnknownKeys(t *testing.T) {
 
 func TestSetNoPromptIfValueNotChanged(t *testing.T) {
 	config := storage.NewMockConfig()
-	config.Set("api.port", "8000", storage.UserConfig)
+	config.Set("api.port", "8080", storage.UserConfig)
 	cmd := setCommand{
 		assumeYes: false, // should not prompt since no change is needed
 		Context: &common.Context{

--- a/cmd/cli/commands/set_test.go
+++ b/cmd/cli/commands/set_test.go
@@ -69,9 +69,7 @@ func TestParseKeyValue(t *testing.T) {
 
 func TestSetValueSuccessForUserConfig(t *testing.T) {
 	mockConfig := storage.NewMockConfig()
-	mockConfig.SetAll(map[string]any{
-		"api.endpoint": "https://old.example.com",
-	}, storage.UserConfig)
+	mockConfig.Set("api.endpoint", "https://old.example.com", storage.UserConfig)
 	cmd := setCommand{
 		noRestart: true,
 		Context: &common.Context{
@@ -117,9 +115,7 @@ func TestSetValueRejectsUnknownKeys(t *testing.T) {
 
 func TestSetNoPromptIfValueNotChanged(t *testing.T) {
 	config := storage.NewMockConfig()
-	config.SetAll(map[string]any{
-		"api.port": "8080",
-	}, storage.UserConfig)
+	config.Set("api.port", "8000", storage.UserConfig)
 	cmd := setCommand{
 		assumeYes: false, // should not prompt since no change is needed
 		Context: &common.Context{
@@ -143,9 +139,7 @@ func ExampleSet_assumeYesRestartServices() {
 	}()
 
 	config := storage.NewMockConfig()
-	config.SetAll(map[string]any{
-		"api.endpoint": "https://old.example.com",
-	}, storage.UserConfig)
+	config.Set("api.endpoint", "https://old.example.com", storage.UserConfig)
 	cmd := setCommand{
 		assumeYes: true,
 		Context: &common.Context{

--- a/cmd/cli/commands/set_test.go
+++ b/cmd/cli/commands/set_test.go
@@ -68,7 +68,7 @@ func TestParseKeyValue(t *testing.T) {
 }
 
 func TestSetValueSuccessForUserConfig(t *testing.T) {
-	config := storage.NewMockConfig(map[string]any{"api.endpoint": "https://old.example.com"})
+	config := storage.NewMockConfig(map[string]any{"user.api.endpoint": "https://old.example.com"})
 	cmd := setCommand{
 		noRestart: true,
 		Context: &common.Context{
@@ -82,13 +82,13 @@ func TestSetValueSuccessForUserConfig(t *testing.T) {
 		t.Fatalf("setValue returned an unexpected error: %v", err)
 	}
 
-	values, err := config.Get("api.endpoint")
+	values, err := config.Get("user.api.endpoint")
 	if err != nil {
 		t.Fatalf("Get returned an unexpected error: %v", err)
 	}
 
-	if value, found := values["api.endpoint"]; !found || value != "https://new.example.com" {
-		t.Fatalf("expected api.endpoint to be set to full value, got %#v", values)
+	if value, found := values["user.api.endpoint"]; !found || value != "https://new.example.com" {
+		t.Fatalf("expected user.api.endpoint to be set to full value, got %#v", values)
 	}
 }
 
@@ -106,14 +106,14 @@ func TestSetValueRejectsUnknownKeys(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unknown key, got nil")
 	} else {
-		if !strings.Contains(err.Error(), "unknown key") {
+		if !strings.Contains(err.Error(), "is not found") {
 			t.Fatalf("expected unknown key error, got: %s", err)
 		}
 	}
 }
 
 func TestSetNoPromptIfValueNotChanged(t *testing.T) {
-	config := storage.NewMockConfig(map[string]any{"api.port": 8080})
+	config := storage.NewMockConfig(map[string]any{"user.api.port": 8080})
 	cmd := setCommand{
 		assumeYes: false, // should not prompt since no change is needed
 		Context: &common.Context{

--- a/cmd/cli/commands/unset.go
+++ b/cmd/cli/commands/unset.go
@@ -46,29 +46,29 @@ func (cmd *unsetCommand) run(_ *cobra.Command, args []string) error {
 	return cmd.unsetValue(args[0])
 }
 
-func (cmd *unsetCommand) unsetValue(keyValue string) error {
-	currValMap, err := cmd.Config.Get(keyValue)
+func (cmd *unsetCommand) unsetValue(key string) error {
+	currValMap, err := cmd.Config.Get(key)
 	if err != nil {
 		return fmt.Errorf("checking existing keys: %s", err)
 	}
-	currVal, found := currValMap[keyValue]
+	currVal, found := currValMap[key]
 	if !found {
-		return fmt.Errorf("key %q is not found\n\nUse \"%s get\" to view available keys", keyValue, cmd.Snap.InstanceName())
+		return fmt.Errorf("%s", common.SuggestKeyNotFound(key))
 	}
 
-	err = cmd.Config.Unset(keyValue, storage.UserConfig)
+	err = cmd.Config.Unset(key, storage.UserConfig)
 	if err != nil {
-		return fmt.Errorf("unsetting %q: %v", keyValue, err)
+		return fmt.Errorf("unsetting %q: %v", key, err)
 	}
 
-	newValMap, err := cmd.Config.Get(keyValue)
+	newValMap, err := cmd.Config.Get(key)
 	if err != nil {
 		return fmt.Errorf("checking existing keys: %s", err)
 	}
-	newVal, _ := newValMap[keyValue]
+	newVal := newValMap[key]
 
 	if fmt.Sprint(currVal) == fmt.Sprint(newVal) {
-		return nil // no change needed
+		return nil // value not changed
 	}
 
 	if !cmd.noRestart {

--- a/cmd/cli/commands/unset.go
+++ b/cmd/cli/commands/unset.go
@@ -53,7 +53,7 @@ func (cmd *unsetCommand) unsetValue(key string) error {
 	}
 	currVal, found := currValMap[key]
 	if !found {
-		return fmt.Errorf("%s", common.SuggestKeyNotFound(key))
+		return fmt.Errorf("Key %q is not found\n\n%s", key, common.SuggestKeyNotFound(key))
 	}
 
 	err = cmd.Config.Unset(key, storage.UserConfig)

--- a/cmd/cli/commands/unset.go
+++ b/cmd/cli/commands/unset.go
@@ -47,9 +47,28 @@ func (cmd *unsetCommand) run(_ *cobra.Command, args []string) error {
 }
 
 func (cmd *unsetCommand) unsetValue(keyValue string) error {
-	err := cmd.Config.Unset(keyValue, storage.UserConfig)
+	currValMap, err := cmd.Config.Get(keyValue)
+	if err != nil {
+		return fmt.Errorf("checking existing keys: %s", err)
+	}
+	currVal, found := currValMap[keyValue]
+	if !found {
+		return fmt.Errorf("key %q is not found\n\nUse \"%s get\" to view available keys", keyValue, cmd.Snap.InstanceName())
+	}
+
+	err = cmd.Config.Unset(keyValue, storage.UserConfig)
 	if err != nil {
 		return fmt.Errorf("unsetting %q: %v", keyValue, err)
+	}
+
+	newValMap, err := cmd.Config.Get(keyValue)
+	if err != nil {
+		return fmt.Errorf("checking existing keys: %s", err)
+	}
+	newVal, _ := newValMap[keyValue]
+
+	if fmt.Sprint(currVal) == fmt.Sprint(newVal) {
+		return nil // no change needed
 	}
 
 	if !cmd.noRestart {

--- a/cmd/cli/commands/unset.go
+++ b/cmd/cli/commands/unset.go
@@ -1,0 +1,64 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/canonical/inference-snaps-cli/cmd/cli/common"
+	"github.com/canonical/inference-snaps-cli/pkg/storage"
+	"github.com/canonical/inference-snaps-cli/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+type unsetCommand struct {
+	*common.Context
+
+	// flags
+	packageConfig bool
+	engineConfig  bool
+	assumeYes     bool
+	noRestart     bool
+}
+
+func Unset(ctx *common.Context) *cobra.Command {
+	var cmd unsetCommand
+	cmd.Context = ctx
+
+	cobraCmd := &cobra.Command{
+		Use:               "unset <key>",
+		Short:             "Unset configurations",
+		Long:              "Unset a user configuration, reverting to package or engine default. If no default exists for the key, it will be removed entirely.",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: cobra.NoFileCompletions,
+		RunE:              cmd.run,
+	}
+
+	cobraCmd.Flags().BoolVar(&cmd.assumeYes, "assume-yes", false, "assume yes for all prompts")
+	cobraCmd.Flags().BoolVar(&cmd.noRestart, "no-restart", false, "do not restart the snap after setting the configuration")
+
+	return cobraCmd
+}
+
+func (cmd *unsetCommand) run(_ *cobra.Command, args []string) error {
+	if !utils.IsRootUser() {
+		return common.ErrPermissionDenied
+	}
+
+	return cmd.unsetValue(args[0])
+}
+
+func (cmd *unsetCommand) unsetValue(keyValue string) error {
+	err := cmd.Config.Unset(keyValue, storage.UserConfig)
+	if err != nil {
+		return fmt.Errorf("unsetting %q: %v", keyValue, err)
+	}
+
+	if !cmd.noRestart {
+		msg := fmt.Sprintf("Restart %s to apply the changes?", cmd.Snap.InstanceName())
+		if cmd.assumeYes || common.PromptYN(msg, true) {
+			if err := cmd.Snap.Restart(); err != nil {
+				return fmt.Errorf("restarting snap: %v", err)
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/cli/commands/unset.go
+++ b/cmd/cli/commands/unset.go
@@ -53,7 +53,7 @@ func (cmd *unsetCommand) unsetValue(key string) error {
 	}
 	currVal, found := currValMap[key]
 	if !found {
-		return fmt.Errorf("Key %q is not found\n\n%s", key, common.SuggestKeyNotFound(key))
+		return fmt.Errorf("key %q is not found\n\n%s", key, common.SuggestKeyNotFound(key))
 	}
 
 	err = cmd.Config.Unset(key, storage.UserConfig)

--- a/cmd/cli/commands/unset_test.go
+++ b/cmd/cli/commands/unset_test.go
@@ -84,7 +84,7 @@ func TestUnsetNonexistentKey(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error when unsetting a non-existent key, got nil")
 	}
-	expectedErrMsg := "Key \"nonexistent-key\" is not found\n\nUse \"mock-snap get\" to view available keys"
+	expectedErrMsg := "key \"nonexistent-key\" is not found\n\nUse \"mock-snap get\" to view available keys"
 	if err.Error() != expectedErrMsg {
 		t.Fatalf("expected error message %q, got %q", expectedErrMsg, err.Error())
 	}

--- a/cmd/cli/commands/unset_test.go
+++ b/cmd/cli/commands/unset_test.go
@@ -9,7 +9,10 @@ import (
 )
 
 func TestUnsetValueRemovesUserConfigWithoutRestart(t *testing.T) {
-	config := storage.NewMockConfig(map[string]any{"user.api.endpoint": "https://example.com"})
+	config := storage.NewMockConfig()
+	config.SetAll(map[string]any{
+		"api.endpoint": "https://example.com",
+	}, storage.UserConfig)
 	cmd := unsetCommand{
 		noRestart: false,
 		assumeYes: true,
@@ -33,7 +36,12 @@ func TestUnsetValueRemovesUserConfigWithoutRestart(t *testing.T) {
 }
 
 func TestUnsetKeyToDefaultValue(t *testing.T) {
-	config := storage.NewMockConfig(map[string]any{"engine.test-key": "engine-value", "package.test-key": "package-value", "user.test-key": "user-value"})
+	config := storage.NewMockConfig()
+	config.SetAll(map[string]any{
+		"engine.test-key":  "engine-value",
+		"package.test-key": "package-value",
+		"test-key":         "user-value",
+	}, storage.UserConfig)
 	cmd := unsetCommand{
 		noRestart: true,
 		assumeYes: true,
@@ -59,8 +67,8 @@ func TestUnsetKeyToDefaultValue(t *testing.T) {
 	}
 }
 
-func TestUnsetInexistentKey(t *testing.T) {
-	config := storage.NewMockConfig(map[string]any{})
+func TestUnsetNonexistentKey(t *testing.T) {
+	config := storage.NewMockConfig()
 	cmd := unsetCommand{
 		noRestart: true,
 		assumeYes: true,

--- a/cmd/cli/commands/unset_test.go
+++ b/cmd/cli/commands/unset_test.go
@@ -11,9 +11,7 @@ import (
 
 func TestUnsetValueRemovesUserConfigWithoutRestart(t *testing.T) {
 	config := storage.NewMockConfig()
-	config.SetAll(map[string]any{
-		"api.endpoint": "https://example.com",
-	}, storage.UserConfig)
+	config.Set("api.endpoint", "https://example.com", storage.UserConfig)
 	cmd := unsetCommand{
 		noRestart: false,
 		assumeYes: true,

--- a/cmd/cli/commands/unset_test.go
+++ b/cmd/cli/commands/unset_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestUnsetValueRemovesUserConfigWithoutRestart(t *testing.T) {
-	config := storage.NewMockConfig(map[string]any{"api.endpoint": "https://example.com"})
+	config := storage.NewMockConfig(map[string]any{"user.api.endpoint": "https://example.com"})
 	cmd := unsetCommand{
 		noRestart: false,
 		assumeYes: true,
@@ -29,5 +29,53 @@ func TestUnsetValueRemovesUserConfigWithoutRestart(t *testing.T) {
 	}
 	if len(values) != 0 {
 		t.Fatalf("expected api.endpoint to be removed, got %#v", values)
+	}
+}
+
+func TestUnsetKeyToDefaultValue(t *testing.T) {
+	config := storage.NewMockConfig(map[string]any{"engine.test-key": "engine-value", "package.test-key": "package-value", "user.test-key": "user-value"})
+	cmd := unsetCommand{
+		noRestart: true,
+		assumeYes: true,
+		Context: &common.Context{
+			Config: config,
+			Snap:   snap.Mock(),
+		},
+	}
+	values, err := config.GetAll()
+	if err != nil {
+		t.Fatalf("GetAll returned an unexpected error: %v", err)
+	}
+	if err := cmd.unsetValue("test-key"); err != nil {
+		t.Fatalf("unsetValue returned an unexpected error: %v", err)
+	}
+
+	values, err = config.Get("test-key")
+	if err != nil {
+		t.Fatalf("Get returned an unexpected error: %v", err)
+	}
+	if values["test-key"] != "engine-value" {
+		t.Fatalf("expected test-key to be overridden by engine config, got %#v", values["test-key"])
+	}
+}
+
+func TestUnsetInexistentKey(t *testing.T) {
+	config := storage.NewMockConfig(map[string]any{})
+	cmd := unsetCommand{
+		noRestart: true,
+		assumeYes: true,
+		Context: &common.Context{
+			Config: config,
+			Snap:   snap.Mock(),
+		},
+	}
+
+	err := cmd.unsetValue("nonexistent-key")
+	if err == nil {
+		t.Fatal("expected an error when unsetting a non-existent key, got nil")
+	}
+	expectedErrMsg := "key \"nonexistent-key\" is not found\n\nUse \"mock-snap get\" to view available keys"
+	if err.Error() != expectedErrMsg {
+		t.Fatalf("expected error message %q, got %q", expectedErrMsg, err.Error())
 	}
 }

--- a/cmd/cli/commands/unset_test.go
+++ b/cmd/cli/commands/unset_test.go
@@ -1,0 +1,33 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/canonical/inference-snaps-cli/cmd/cli/common"
+	"github.com/canonical/inference-snaps-cli/pkg/snap"
+	"github.com/canonical/inference-snaps-cli/pkg/storage"
+)
+
+func TestUnsetValueRemovesUserConfigWithoutRestart(t *testing.T) {
+	config := storage.NewMockConfig(map[string]any{"api.endpoint": "https://example.com"})
+	cmd := unsetCommand{
+		noRestart: false,
+		assumeYes: true,
+		Context: &common.Context{
+			Config: config,
+			Snap:   snap.Mock(),
+		},
+	}
+
+	if err := cmd.unsetValue("api.endpoint"); err != nil {
+		t.Fatalf("unsetValue returned an unexpected error: %v", err)
+	}
+
+	values, err := config.Get("api.endpoint")
+	if err != nil {
+		t.Fatalf("Get returned an unexpected error: %v", err)
+	}
+	if len(values) != 0 {
+		t.Fatalf("expected api.endpoint to be removed, got %#v", values)
+	}
+}

--- a/cmd/cli/commands/unset_test.go
+++ b/cmd/cli/commands/unset_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"os"
 	"testing"
 
 	"github.com/canonical/inference-snaps-cli/cmd/cli/common"
@@ -37,11 +38,9 @@ func TestUnsetValueRemovesUserConfigWithoutRestart(t *testing.T) {
 
 func TestUnsetKeyToDefaultValue(t *testing.T) {
 	config := storage.NewMockConfig()
-	config.SetAll(map[string]any{
-		"engine.test-key":  "engine-value",
-		"package.test-key": "package-value",
-		"test-key":         "user-value",
-	}, storage.UserConfig)
+	config.Set("test-key", "user-value", storage.UserConfig)
+	config.Set("test-key", "engine-value", storage.EngineConfig)
+	config.Set("test-key", "package-value", storage.PackageConfig)
 	cmd := unsetCommand{
 		noRestart: true,
 		assumeYes: true,
@@ -77,12 +76,17 @@ func TestUnsetNonexistentKey(t *testing.T) {
 			Snap:   snap.Mock(),
 		},
 	}
-
+	if err := os.Setenv("SNAP_INSTANCE_NAME", "mock-snap"); err != nil {
+		panic(err)
+	}
+	defer func() {
+		_ = os.Unsetenv("SNAP_INSTANCE_NAME")
+	}()
 	err := cmd.unsetValue("nonexistent-key")
 	if err == nil {
 		t.Fatal("expected an error when unsetting a non-existent key, got nil")
 	}
-	expectedErrMsg := "key \"nonexistent-key\" is not found\n\nUse \"mock-snap get\" to view available keys"
+	expectedErrMsg := "Key \"nonexistent-key\" is not found\n\nUse \"mock-snap get\" to view available keys"
 	if err.Error() != expectedErrMsg {
 		t.Fatalf("expected error message %q, got %q", expectedErrMsg, err.Error())
 	}

--- a/cmd/cli/common/endpoints_test.go
+++ b/cmd/cli/common/endpoints_test.go
@@ -70,7 +70,7 @@ func TestServerEndpoints(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			config := storage.NewMockConfig()
-			config.SetAll(map[string]any{"http.port": "8080"}, storage.UserConfig)
+			config.Set("http.port", "8080", storage.UserConfig)
 			ctx := &Context{
 				Config: config,
 			}
@@ -141,7 +141,7 @@ func TestServerHttpUrl(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			config := storage.NewMockConfig()
-			config.SetAll(map[string]any{"http.port": "8080"}, storage.UserConfig)
+			config.Set("http.port", "8080", storage.UserConfig)
 			ctx := &Context{
 				Config: config,
 			}

--- a/cmd/cli/common/endpoints_test.go
+++ b/cmd/cli/common/endpoints_test.go
@@ -69,8 +69,10 @@ func TestServerEndpoints(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			config := storage.NewMockConfig()
+			config.SetAll(map[string]any{"http.port": "8080"}, storage.UserConfig)
 			ctx := &Context{
-				Config: storage.NewMockConfig(map[string]any{"http.port": "8080"}),
+				Config: config,
 			}
 
 			got, err := serverEndpoints(ctx, testCase.componentConfigs)
@@ -138,8 +140,10 @@ func TestServerHttpUrl(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			config := storage.NewMockConfig()
+			config.SetAll(map[string]any{"http.port": "8080"}, storage.UserConfig)
 			ctx := &Context{
-				Config: storage.NewMockConfig(map[string]any{"http.port": "8080"}),
+				Config: config,
 			}
 
 			got, err := serverHttpUrl(ctx, testCase.serverConfig)

--- a/cmd/cli/common/suggestions.go
+++ b/cmd/cli/common/suggestions.go
@@ -73,5 +73,5 @@ func SuggestKeyNotFound(key string) string {
 		instanceName = "<snap-instance-name>"
 	}
 
-	return fmt.Sprintf("Key %q is not found\n\nUse \"%s get\" to view available keys", key, instanceName)
+	return fmt.Sprintf("Use \"%s get\" to view available keys", instanceName)
 }

--- a/cmd/cli/common/suggestions.go
+++ b/cmd/cli/common/suggestions.go
@@ -66,3 +66,12 @@ func SuggestEngineInfo() string {
 
 	return fmt.Sprintf("Use \"%v show-engine <engine>\" for more information about an engine.", instanceName)
 }
+
+func SuggestKeyNotFound(key string) string {
+	instanceName := env.SnapInstanceName()
+	if instanceName == "" { // not a snap
+		instanceName = "<snap-instance-name>"
+	}
+
+	return fmt.Sprintf("Key %q is not found\n\nUse \"%s get\" to view available keys", key, instanceName)
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -86,6 +86,7 @@ func main() {
 	addCommandGroup(rootCmd, "config", "Configuration Commands:",
 		commands.Get(ctx),
 		commands.Set(ctx),
+		commands.Unset(ctx),
 	)
 
 	addCommandGroup(rootCmd, "engine", "Management Commands:",

--- a/pkg/storage/mock_config.go
+++ b/pkg/storage/mock_config.go
@@ -17,24 +17,49 @@ func NewMockConfig(values map[string]any) Config {
 }
 
 func (c *mockConfig) Set(key, value string, confType configType) error {
-	c.values[key] = value
+	scopedKey := string(confType) + "." + key
+	c.values[scopedKey] = value
 	return nil
 }
 
 func (c *mockConfig) SetDocument(key string, value any, confType configType) error {
-	c.values[key] = value
+	scopedKey := string(confType) + "." + key
+	c.values[scopedKey] = value
 	return nil
 }
 
 func (c *mockConfig) Get(key string) (map[string]any, error) {
-	result := make(map[string]any)
-	for k, v := range c.values {
-		if k == key || strings.HasPrefix(k, key+".") {
-			result[k] = v
+	if value, found := c.values[key]; found {
+		return map[string]any{key: value}, nil
+	}
+
+	for _, confType := range []configType{UserConfig, EngineConfig, PackageConfig} {
+		scopedKey := string(confType) + "." + key
+		if value, found := c.values[scopedKey]; found {
+			return map[string]any{key: value}, nil
 		}
 	}
 
-	return result, nil
+	result := make(map[string]any)
+	for _, confType := range []configType{UserConfig, EngineConfig, PackageConfig} {
+		prefix := string(confType) + "." + key + "."
+		for fullKey, value := range c.values {
+			if !strings.HasPrefix(fullKey, prefix) {
+				continue
+			}
+
+			normalizedKey := strings.TrimPrefix(fullKey, string(confType)+".")
+			if _, exists := result[normalizedKey]; !exists {
+				result[normalizedKey] = value
+			}
+		}
+	}
+
+	if len(result) > 0 {
+		return result, nil
+	}
+
+	return map[string]any{}, nil
 }
 
 func (c *mockConfig) GetAll() (map[string]any, error) {
@@ -44,6 +69,7 @@ func (c *mockConfig) GetAll() (map[string]any, error) {
 }
 
 func (c *mockConfig) Unset(key string, confType configType) error {
-	delete(c.values, key)
+	scopedKey := string(confType) + "." + key
+	delete(c.values, scopedKey)
 	return nil
 }

--- a/pkg/storage/mock_config.go
+++ b/pkg/storage/mock_config.go
@@ -5,29 +5,29 @@ import (
 	"strings"
 )
 
-type MockConfig struct {
+type mockConfig struct {
 	values map[string]any
 }
 
 func NewMockConfig() Config {
 	configValues := make(map[string]any)
 
-	return &MockConfig{values: configValues}
+	return &mockConfig{values: configValues}
 }
 
-func (c *MockConfig) Set(key, value string, confType configType) error {
+func (c *mockConfig) Set(key, value string, confType configType) error {
 	scopedKey := string(confType) + "." + key
 	c.values[scopedKey] = value
 	return nil
 }
 
-func (c *MockConfig) SetDocument(key string, value any, confType configType) error {
+func (c *mockConfig) SetDocument(key string, value any, confType configType) error {
 	scopedKey := string(confType) + "." + key
 	c.values[scopedKey] = value
 	return nil
 }
 
-func (c *MockConfig) Get(key string) (map[string]any, error) {
+func (c *mockConfig) Get(key string) (map[string]any, error) {
 	if value, found := c.values[key]; found {
 		return map[string]any{key: value}, nil
 	}
@@ -61,13 +61,13 @@ func (c *MockConfig) Get(key string) (map[string]any, error) {
 	return map[string]any{}, nil
 }
 
-func (c *MockConfig) GetAll() (map[string]any, error) {
+func (c *mockConfig) GetAll() (map[string]any, error) {
 	allValues := make(map[string]any)
 	maps.Copy(allValues, c.values)
 	return allValues, nil
 }
 
-func (c *MockConfig) Unset(key string, confType configType) error {
+func (c *mockConfig) Unset(key string, confType configType) error {
 	scopedKey := string(confType) + "." + key
 	delete(c.values, scopedKey)
 	return nil

--- a/pkg/storage/mock_config.go
+++ b/pkg/storage/mock_config.go
@@ -9,7 +9,7 @@ type MockConfig struct {
 	values map[string]any
 }
 
-func NewMockConfig() *MockConfig {
+func NewMockConfig() Config {
 	configValues := make(map[string]any)
 
 	return &MockConfig{values: configValues}
@@ -18,15 +18,6 @@ func NewMockConfig() *MockConfig {
 func (c *MockConfig) Set(key, value string, confType configType) error {
 	scopedKey := string(confType) + "." + key
 	c.values[scopedKey] = value
-	return nil
-}
-
-// SetAll sets multiple key/value pairs at once under the given config type.
-func (c *MockConfig) SetAll(values map[string]any, confType configType) error {
-	for k, v := range values {
-		scopedKey := string(confType) + "." + k
-		c.values[scopedKey] = v
-	}
 	return nil
 }
 

--- a/pkg/storage/mock_config.go
+++ b/pkg/storage/mock_config.go
@@ -5,30 +5,38 @@ import (
 	"strings"
 )
 
-type mockConfig struct {
+type MockConfig struct {
 	values map[string]any
 }
 
-func NewMockConfig(values map[string]any) Config {
+func NewMockConfig() *MockConfig {
 	configValues := make(map[string]any)
-	maps.Copy(configValues, values)
 
-	return &mockConfig{values: configValues}
+	return &MockConfig{values: configValues}
 }
 
-func (c *mockConfig) Set(key, value string, confType configType) error {
+func (c *MockConfig) Set(key, value string, confType configType) error {
 	scopedKey := string(confType) + "." + key
 	c.values[scopedKey] = value
 	return nil
 }
 
-func (c *mockConfig) SetDocument(key string, value any, confType configType) error {
+// SetAll sets multiple key/value pairs at once under the given config type.
+func (c *MockConfig) SetAll(values map[string]any, confType configType) error {
+	for k, v := range values {
+		scopedKey := string(confType) + "." + k
+		c.values[scopedKey] = v
+	}
+	return nil
+}
+
+func (c *MockConfig) SetDocument(key string, value any, confType configType) error {
 	scopedKey := string(confType) + "." + key
 	c.values[scopedKey] = value
 	return nil
 }
 
-func (c *mockConfig) Get(key string) (map[string]any, error) {
+func (c *MockConfig) Get(key string) (map[string]any, error) {
 	if value, found := c.values[key]; found {
 		return map[string]any{key: value}, nil
 	}
@@ -62,13 +70,13 @@ func (c *mockConfig) Get(key string) (map[string]any, error) {
 	return map[string]any{}, nil
 }
 
-func (c *mockConfig) GetAll() (map[string]any, error) {
+func (c *MockConfig) GetAll() (map[string]any, error) {
 	allValues := make(map[string]any)
 	maps.Copy(allValues, c.values)
 	return allValues, nil
 }
 
-func (c *mockConfig) Unset(key string, confType configType) error {
+func (c *MockConfig) Unset(key string, confType configType) error {
 	scopedKey := string(confType) + "." + key
 	delete(c.values, scopedKey)
 	return nil


### PR DESCRIPTION
Unset command can be used to remove configuration set at `user` level.
It does not affect `engine` or `package` level.
If unset is called on a configuration which has a default value, default value will be restore. Otherwise, configuration key will be deleted