### PR TITLE
Chat: use `reasoning_content` for thinking

### DIFF
--- a/cmd/cli/common/chat.go
+++ b/cmd/cli/common/chat.go
@@ -335,7 +335,7 @@ func (c *chatClient) processStream(stream *ssestream.Stream[openai.ChatCompletio
 				thinking = true
 				fmt.Printf("%s", color.BlueString(reasoningChunk))
 			}
-			// If the response has main content, and we were printing reasoning, add a new line
+			// If the response has main content, but we were printing reasoning, add a new line to split them
 			if thinking && contentChunk != "" {
 				thinking = false
 				fmt.Print("\n\n")

--- a/cmd/cli/common/chat.go
+++ b/cmd/cli/common/chat.go
@@ -334,15 +334,15 @@ func (c *chatClient) processStream(stream *ssestream.Stream[openai.ChatCompletio
 			if reasoningChunk != "" {
 				thinking = true
 				fmt.Printf("%s", color.BlueString(reasoningChunk))
-			} else if thinking && contentChunk != "" {
-				// Reasoning just ended, print a blank line before the main response
+			}
+			// If the response has main content, and we were printing reasoning, add a new line
+			if thinking && contentChunk != "" {
 				thinking = false
 				fmt.Print("\n\n")
 			}
 
 			// Main response
 			fmt.Printf("%s", contentChunk)
-
 		}
 	}
 

--- a/cmd/cli/common/chat.go
+++ b/cmd/cli/common/chat.go
@@ -295,7 +295,6 @@ func (c *chatClient) processStream(stream *ssestream.Stream[openai.ChatCompletio
 	// optionally, an accumulator helper can be used
 	acc := openai.ChatCompletionAccumulator{}
 
-	// An opening <think> tag will change the output color to indicate reasoning.
 	thinking := false
 
 	for stream.Next() {
@@ -317,21 +316,33 @@ func (c *chatClient) processStream(stream *ssestream.Stream[openai.ChatCompletio
 
 		// Print chunks as they are received
 		if len(chunk.Choices) > 0 {
-			lastChunk := chunk.Choices[0].Delta.Content
 
-			if strings.Contains(lastChunk, "<think>") {
-				thinking = true
-				fmt.Printf("%s", color.BlueString(lastChunk))
-			} else if strings.Contains(lastChunk, "</think>") {
-				thinking = false
-				fmt.Printf("%s", color.BlueString(lastChunk))
-
-			} else if thinking {
-				fmt.Printf("%s", color.BlueString(lastChunk))
-
-			} else {
-				fmt.Printf("%s", lastChunk)
+			// Gemma-4 and Nemotron-3 uses a field `reasoning_content` for thinking.
+			// The OpenAI library does not contain it, so parse it manually.
+			var rawDelta struct {
+				ReasoningContent string `json:"reasoning_content"`
 			}
+			err := json.Unmarshal([]byte(chunk.Choices[0].Delta.RawJSON()), &rawDelta)
+			if err != nil {
+				// ignore err and continue printing main content
+			}
+
+			contentChunk := chunk.Choices[0].Delta.Content
+			reasoningChunk := rawDelta.ReasoningContent
+
+			// Print thinking
+			if reasoningChunk != "" {
+				thinking = true
+				fmt.Printf("%s", color.BlueString(reasoningChunk))
+			} else if thinking && contentChunk != "" {
+				// Reasoning just ended, print a blank line before the main response
+				thinking = false
+				fmt.Print("\n\n")
+			}
+
+			// Main response
+			fmt.Printf("%s", contentChunk)
+
 		}
 	}
 

--- a/cmd/cli/common/chat.go
+++ b/cmd/cli/common/chat.go
@@ -324,7 +324,7 @@ func (c *chatClient) processStream(stream *ssestream.Stream[openai.ChatCompletio
 			}
 			err := json.Unmarshal([]byte(chunk.Choices[0].Delta.RawJSON()), &rawDelta)
 			if err != nil {
-				// ignore err and continue printing main content
+				return nil, fmt.Errorf("unmarshalling response chunk: %v", err)
 			}
 
 			contentChunk := chunk.Choices[0].Delta.Content

--- a/cmd/cli/common/chat.go
+++ b/cmd/cli/common/chat.go
@@ -317,7 +317,7 @@ func (c *chatClient) processStream(stream *ssestream.Stream[openai.ChatCompletio
 		// Print chunks as they are received
 		if len(chunk.Choices) > 0 {
 
-			// Gemma-4 and Nemotron-3 uses a field `reasoning_content` for thinking.
+			// Gemma-4 and Nemotron-3 set a `reasoning_content` field for thinking output.
 			// The OpenAI library does not contain it, so parse it manually.
 			var rawDelta struct {
 				ReasoningContent string `json:"reasoning_content"`


### PR DESCRIPTION
## Background

DeepSeek-R1 used a `<think/>` tag to show when the reasoning ended and when the main response started. The opening `<think>` tag was always missing. The `chat` was written to assume a response from DeepSeek-R1 is always started in thinking mode, and it ends when the closing tag is seen. We later removed this assumption, and required an opening `<think>` tag to trigger formatting the response as reasoning.

With Gemma-4 and Nemotron-3 we see that they do not use the think tags. They instead use a dedicated field in the response json called `reasoning_content`, with the main response content being in the `content` field.

Our webui already handled the `reasoning_content` response field correctly.

I can not find any formal documentation about this field, and the OpenAI API library we use does not implement it. Only vLLM mentions it:
https://docs.vllm.ai/en/v0.8.2/features/reasoning_outputs.html

## This PR

We drop support for the think-tags, as only DeepSeek-R1 used them (incorrectly).

We implement the `reasoning_content` field and use that to render the thinking text.

Limitations:
* Every transition from `reasoning_content` to main `content` will print a blank line. If we do not do this, there will be no space between the two. For our current models this is fine because reasoning output is always received first, and then followed by main content. If this changes, we will need to revisit this.

Tested with both Gemma-4 and Nemtron-3-nano:
<img width="3031" height="936" alt="Screenshot From 2026-04-23 17-23-43" src="https://github.com/user-attachments/assets/2694af9a-2324-410b-ad25-6bb797c04205" />
