### PR TITLE
Remove warning printouts from library

### DIFF
--- a/cmd/cli/commands/debug/select.go
+++ b/cmd/cli/commands/debug/select.go
@@ -62,14 +62,10 @@ func (cmd *selectCommand) run(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("loading engines from directory: %s", err)
 	}
 
-	stopProgress := common.StartProgressSpinner(common.ProgressScoring)
-	defer stopProgress()
-
 	scoredEngines, err := selector.ScoreEngines(&hardwareInfo, allEngines)
 	if err != nil {
 		return fmt.Errorf("checking engines: %s", err)
 	}
-	stopProgress()
 
 	var engineSelection EngineSelection
 

--- a/cmd/cli/commands/list-engines.go
+++ b/cmd/cli/commands/list-engines.go
@@ -52,14 +52,10 @@ func ListEngines(ctx *common.Context) *cobra.Command {
 }
 
 func (cmd *listEnginesCommand) run(_ *cobra.Command, _ []string) error {
-	stopProgress := common.StartProgressSpinner(common.ProgressScoring)
-	defer stopProgress()
-
-	scoredEngines, err := common.ScoreEngines(cmd.Context)
+	scoredEngines, err := common.ScoreEnginesWithSpinner(cmd.Context)
 	if err != nil {
-		return fmt.Errorf("checking engines: %v", err)
+		return fmt.Errorf("scoring engines: %v", err)
 	}
-	stopProgress()
 
 	activeEngine, err := cmd.Cache.GetActiveEngine()
 	if err != nil {

--- a/cmd/cli/commands/show-engine.go
+++ b/cmd/cli/commands/show-engine.go
@@ -84,14 +84,10 @@ func (cmd *showEngineCommand) showCurrentEngine() error {
 }
 
 func (cmd *showEngineCommand) showEngine(engineName string) error {
-	stopProgress := common.StartProgressSpinner(common.ProgressScoring)
-	defer stopProgress()
-
-	scoredEngines, err := common.ScoreEngines(cmd.Context)
+	scoredEngines, err := common.ScoreEnginesWithSpinner(cmd.Context)
 	if err != nil {
-		return fmt.Errorf("checking engines: %v", err)
+		return fmt.Errorf("scoring engines: %v", err)
 	}
-	stopProgress()
 
 	var scoredManifest engines.ScoredManifest
 	for i := range scoredEngines {

--- a/cmd/cli/commands/show-machine.go
+++ b/cmd/cli/commands/show-machine.go
@@ -3,10 +3,12 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/canonical/inference-snaps-cli/cmd/cli/common"
 	"github.com/canonical/inference-snaps-cli/pkg/hardware_info"
+	"github.com/canonical/inference-snaps-cli/pkg/types"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -44,20 +46,20 @@ func ShowMachine(ctx *common.Context) *cobra.Command {
 }
 
 func (cmd *showMachineCommand) run(_ *cobra.Command, _ []string) error {
-	hwInfo, err := hardware_info.Get(true)
+	info, err := cmd.fetchMachineInfoWithSpinner()
 	if err != nil {
-		return fmt.Errorf("getting machine info: %s", err)
+		return err
 	}
 
 	switch cmd.format {
 	case "json":
-		jsonString, err := json.MarshalIndent(hwInfo, "", "  ")
+		jsonString, err := json.MarshalIndent(info, "", "  ")
 		if err != nil {
 			return fmt.Errorf("json: %s", err)
 		}
 		fmt.Printf("%s\n", jsonString)
 	case "yaml":
-		yamlString, err := yaml.Marshal(hwInfo)
+		yamlString, err := yaml.Marshal(info)
 		if err != nil {
 			return fmt.Errorf("yaml: %s", err)
 		}
@@ -67,4 +69,22 @@ func (cmd *showMachineCommand) run(_ *cobra.Command, _ []string) error {
 	}
 
 	return nil
+}
+
+func (cmd *showMachineCommand) fetchMachineInfoWithSpinner() (*types.HwInfo, error) {
+	stopProgress := common.StartProgressSpinner("Getting machine info")
+	hwInfo, warnings, err := hardware_info.Get(true)
+	stopProgress()
+
+	if len(warnings) > 0 {
+		for _, warning := range warnings {
+			fmt.Fprintf(os.Stderr, "Warning: %s\n", warning)
+		}
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("getting machine info: %s", err)
+	}
+
+	return hwInfo, nil
 }

--- a/cmd/cli/commands/show-machine.go
+++ b/cmd/cli/commands/show-machine.go
@@ -72,7 +72,7 @@ func (cmd *showMachineCommand) run(_ *cobra.Command, _ []string) error {
 }
 
 func (cmd *showMachineCommand) fetchMachineInfoWithSpinner() (*types.HwInfo, error) {
-	stopProgress := common.StartProgressSpinner("Getting machine info")
+	stopProgress := common.StartProgressSpinner("Gathering machine information")
 	hwInfo, warnings, err := hardware_info.Get(true)
 	stopProgress()
 

--- a/cmd/cli/commands/use-engine.go
+++ b/cmd/cli/commands/use-engine.go
@@ -89,14 +89,10 @@ func (cmd *useEngineCommand) run(_ *cobra.Command, args []string) error {
 }
 
 func (cmd *useEngineCommand) autoSelectEngine() error {
-	stopProgress := common.StartProgressSpinner(common.ProgressScoring)
-	defer stopProgress()
-
-	scoredEngines, err := common.ScoreEngines(cmd.Context)
+	scoredEngines, err := common.ScoreEnginesWithSpinner(cmd.Context)
 	if err != nil {
-		return fmt.Errorf("checking engines: %v", err)
+		return fmt.Errorf("scoring engines: %v", err)
 	}
-	stopProgress()
 
 	fmt.Println("Evaluating engines for optimal hardware compatibility:")
 	for _, engine := range scoredEngines {

--- a/cmd/cli/common/engine.go
+++ b/cmd/cli/common/engine.go
@@ -230,7 +230,7 @@ func ScoreEngines(ctx *Context) ([]engines.ScoredManifest, []string, error) {
 // ScoreEnginesWithSpinner is same as ScoreEngines but with a progress spinner.
 // It prints the warnings to stderr.
 func ScoreEnginesWithSpinner(ctx *Context) ([]engines.ScoredManifest, error) {
-	stopProgress := StartProgressSpinner("Checking engines")
+	stopProgress := StartProgressSpinner("Checking engine compatibility")
 	scoredEngines, warnings, err := ScoreEngines(ctx)
 	stopProgress()
 

--- a/cmd/cli/common/engine.go
+++ b/cmd/cli/common/engine.go
@@ -16,8 +16,7 @@ import (
 )
 
 const (
-	componentEnv    = "COMPONENT"
-	ProgressScoring = "Checking engines"
+	componentEnv = "COMPONENT"
 )
 
 type ComponentLayout struct {
@@ -209,20 +208,38 @@ and scores the engines according to their compatibility with the host.
 
 Warning: calls to this function can block for a number of seconds while the host machine information is being looked up.
 */
-func ScoreEngines(ctx *Context) ([]engines.ScoredManifest, error) {
+func ScoreEngines(ctx *Context) ([]engines.ScoredManifest, []string, error) {
 	allEngines, err := engines.LoadManifests(ctx.EnginesDir)
 	if err != nil {
-		return nil, fmt.Errorf("loading engines: %v", err)
+		return nil, nil, fmt.Errorf("loading engines: %v", err)
 	}
 
-	machineInfo, err := hardware_info.Get(false)
+	machineInfo, warnings, err := hardware_info.Get(false)
 	if err != nil {
-		return nil, fmt.Errorf("getting machine info: %v", err)
+		return nil, nil, fmt.Errorf("getting machine info: %v", err)
 	}
 
 	scoredEngines, err := selector.ScoreEngines(machineInfo, allEngines)
 	if err != nil {
-		return nil, fmt.Errorf("scoring engines: %v", err)
+		return nil, nil, fmt.Errorf("scoring engines: %v", err)
+	}
+
+	return scoredEngines, warnings, nil
+}
+
+func ScoreEnginesWithSpinner(ctx *Context) ([]engines.ScoredManifest, error) {
+	stopProgress := StartProgressSpinner("Checking engines")
+	scoredEngines, warnings, err := ScoreEngines(ctx)
+	stopProgress()
+
+	if len(warnings) > 0 {
+		for _, warning := range warnings {
+			fmt.Fprintf(os.Stderr, "Warning: %s\n", warning)
+		}
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("checking engines: %v", err)
 	}
 
 	return scoredEngines, nil

--- a/cmd/cli/common/engine.go
+++ b/cmd/cli/common/engine.go
@@ -227,6 +227,8 @@ func ScoreEngines(ctx *Context) ([]engines.ScoredManifest, []string, error) {
 	return scoredEngines, warnings, nil
 }
 
+// ScoreEnginesWithSpinner is same as ScoreEngines but with a progress spinner.
+// It prints the warnings to stderr.
 func ScoreEnginesWithSpinner(ctx *Context) ([]engines.ScoredManifest, error) {
 	stopProgress := StartProgressSpinner("Checking engines")
 	scoredEngines, warnings, err := ScoreEngines(ctx)
@@ -238,9 +240,5 @@ func ScoreEnginesWithSpinner(ctx *Context) ([]engines.ScoredManifest, error) {
 		}
 	}
 
-	if err != nil {
-		return nil, fmt.Errorf("checking engines: %v", err)
-	}
-
-	return scoredEngines, nil
+	return scoredEngines, err
 }

--- a/pkg/hardware_info/hardware-info.go
+++ b/pkg/hardware_info/hardware-info.go
@@ -13,37 +13,37 @@ import (
 	"github.com/canonical/inference-snaps-cli/pkg/types"
 )
 
-func Get(friendlyNames bool) (*types.HwInfo, error) {
+func Get(friendlyNames bool) (*types.HwInfo, []string, error) {
 	var hwInfo types.HwInfo
 
 	memoryInfo, err := memory.Info()
 	if err != nil {
-		return nil, fmt.Errorf("getting memory info: %v", err)
+		return nil, nil, fmt.Errorf("getting memory info: %v", err)
 	}
 	hwInfo.Memory = memoryInfo
 
 	cpus, err := cpu.Info()
 	if err != nil {
-		return nil, fmt.Errorf("getting cpu info: %v", err)
+		return nil, nil, fmt.Errorf("getting cpu info: %v", err)
 	}
 	hwInfo.Cpus = cpus
 
 	diskInfo, err := disk.Info()
 	if err != nil {
-		return nil, fmt.Errorf("getting disk info: %v", err)
+		return nil, nil, fmt.Errorf("getting disk info: %v", err)
 	}
 	hwInfo.Disk = diskInfo
 
-	pciDevices, err := pci.Devices(friendlyNames)
+	pciDevices, warnings, err := pci.Devices(friendlyNames)
 	if err != nil {
-		return nil, fmt.Errorf("getting pci devices: %v", err)
+		return nil, nil, fmt.Errorf("getting pci devices: %v", err)
 	}
 	hwInfo.PciDevices = pciDevices
 
-	return &hwInfo, nil
+	return &hwInfo, warnings, nil
 }
 
-// GetFromRawData is mainly used during testing, but also from other packages, and therefore needs to be exported
+// GetFromRawData is a test helper
 func GetFromRawData(t *testing.T, device string, friendlyNames bool, testDir string) (*types.HwInfo, error) {
 	var hwInfo types.HwInfo
 
@@ -91,7 +91,10 @@ func GetFromRawData(t *testing.T, device string, friendlyNames bool, testDir str
 	if err != nil {
 		t.Fatal(err)
 	}
-	pciDevices, err := pci.DevicesFromRawData(string(pciData), friendlyNames)
+	pciDevices, warnings, err := pci.DevicesFromRawData(string(pciData), friendlyNames)
+	if len(warnings) > 0 {
+		t.Logf("Warnings: %v", warnings)
+	}
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/hardware_info/pci/lspci.go
+++ b/pkg/hardware_info/pci/lspci.go
@@ -2,7 +2,6 @@ package pci
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -19,8 +18,9 @@ func hostLsPci() (string, error) {
 	return string(out), nil
 }
 
-func ParseLsPci(inputString string, includeFriendlyNames bool) ([]types.PciDevice, error) {
+func ParseLsPci(inputString string, includeFriendlyNames bool) ([]types.PciDevice, []string, error) {
 	var devices []types.PciDevice
+	var warnings []string
 
 	for _, section := range strings.Split(inputString, "\n\n") {
 		// Ignore empty devices, e.g. extra blank line at end
@@ -37,11 +37,11 @@ func ParseLsPci(inputString string, includeFriendlyNames bool) ([]types.PciDevic
 				// Parse slot value into bus number: 0000:3b:00.0 -> 3B
 				parts := strings.Split(value, ":")
 				if len(parts) != 3 {
-					return nil, fmt.Errorf("unexpected format for pci slot: %s", value)
+					return nil, nil, fmt.Errorf("unexpected format for pci slot: %s", value)
 				}
 				busNumber, err := strconv.ParseUint(parts[1], 16, 8)
 				if err != nil {
-					return nil, fmt.Errorf("cannot parse pci bus number: %s", parts[1])
+					return nil, nil, fmt.Errorf("cannot parse pci bus number: %s", parts[1])
 				}
 				device.BusNumber = types.HexInt(busNumber)
 			case "Class":
@@ -79,8 +79,8 @@ func ParseLsPci(inputString string, includeFriendlyNames bool) ([]types.PciDevic
 		if includeFriendlyNames {
 			friendlyNames, err := friendlyNames(device)
 			if err != nil {
-				// This is not a fatal error, so just logging it
-				fmt.Fprintln(os.Stderr, "Warning: unable to get friendly name for pci device:", err)
+				// This is not a fatal error, record a warning and continue
+				warnings = append(warnings, fmt.Sprintf("unable to get friendly name for pci device: %s", err))
 			} else {
 				device.PciFriendlyNames = friendlyNames
 			}
@@ -88,5 +88,5 @@ func ParseLsPci(inputString string, includeFriendlyNames bool) ([]types.PciDevic
 		devices = append(devices, device)
 	}
 
-	return devices, nil
+	return devices, warnings, nil
 }

--- a/pkg/hardware_info/pci/lspci_test.go
+++ b/pkg/hardware_info/pci/lspci_test.go
@@ -31,7 +31,10 @@ func TestParseLsCpu(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, err = ParseLsPci(string(lsPci), true)
+			_, warnings, err := ParseLsPci(string(lsPci), true)
+			if len(warnings) > 0 {
+				t.Logf("Warnings: %v", warnings)
+			}
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/hardware_info/pci/pci_devices.go
+++ b/pkg/hardware_info/pci/pci_devices.go
@@ -3,7 +3,6 @@ package pci
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/canonical/inference-snaps-cli/pkg/constants"
 	"github.com/canonical/inference-snaps-cli/pkg/hardware_info/pci/amd"
@@ -21,31 +20,32 @@ var (
 /*
 Devices returns a slice of PciDevices that is detected on the current system and reported by lspci.
 */
-func Devices(friendlyNames bool) ([]types.PciDevice, error) {
+func Devices(friendlyNames bool) ([]types.PciDevice, []string, error) {
 
 	hostLsPciData, err := hostLsPci()
 	if err != nil {
-		return nil, fmt.Errorf("executing lspci: %v", err)
+		return nil, nil, fmt.Errorf("executing lspci: %v", err)
 	}
-	devices, err := ParseLsPci(hostLsPciData, friendlyNames)
+	devices, lsPciWarnings, err := ParseLsPci(hostLsPciData, friendlyNames)
 	if err != nil {
-		return nil, fmt.Errorf("parsing lspci output: %v", err)
+		return nil, nil, fmt.Errorf("parsing lspci output: %v", err)
 	}
 
 	// Additional properties are obtained by running vendor specific tools on the host
 	// Errors are not fatal, and are printed to stderr
-	devices = addAdditionalProperties(devices)
+	devices, additionalPropWarnings := addAdditionalProperties(devices)
 
-	return devices, nil
+	warnings := append(lsPciWarnings, additionalPropWarnings...)
+	return devices, warnings, nil
 }
 
-func DevicesFromRawData(lspciData string, friendlyNames bool) ([]types.PciDevice, error) {
-	devices, err := ParseLsPci(lspciData, friendlyNames)
+func DevicesFromRawData(lspciData string, friendlyNames bool) ([]types.PciDevice, []string, error) {
+	devices, warnings, err := ParseLsPci(lspciData, friendlyNames)
 	if err != nil {
-		return nil, fmt.Errorf("parsing lspci output: %v", err)
+		return nil, nil, fmt.Errorf("parsing lspci output: %v", err)
 	}
 
-	return devices, nil
+	return devices, warnings, nil
 }
 
 /*
@@ -115,20 +115,22 @@ Additional properties are obtained by running vendor specific tools on the host 
 No error is returned as a failure to look up properties is considered non-fatal, and likely due to missing drivers.
 Errors are instead logged to STDERR.
 */
-func addAdditionalProperties(devices []types.PciDevice) []types.PciDevice {
+func addAdditionalProperties(devices []types.PciDevice) ([]types.PciDevice, []string) {
+	var warnings []string
+
 	for i, device := range devices {
 		properties, err := deviceAdditionalProperties(device)
 		if err != nil {
 			if errors.Is(err, ErrorVendorNotSupported) {
 				// We do not log unsupported vendors, as that would be the majority of PCI devices
 			} else {
-				fmt.Fprintf(os.Stderr, "Warning: unable to get additional properties for pci device: %v\n", err)
+				warnings = append(warnings, fmt.Sprintf("unable to get additional properties for pci device: %s", err))
 			}
 		}
 		devices[i].AdditionalProperties = properties
 	}
 
-	return devices
+	return devices, warnings
 }
 
 func deviceAdditionalProperties(device types.PciDevice) (map[string]string, error) {


### PR DESCRIPTION
The library prints two warnings. In a few cases, the caller uses a spinner for slow operations and the printed warnings interrupt the spinner. For example:
```
$ gemma4 list-engines 
Checking engines |Warning: unable to get additional properties for pci device: Intel: getting gpu properties: looking up vram: executing clinfo: exec: "clinfo": executable file not found in $PATH
Checking engines \Warning: unable to get additional properties for pci device: NVIDIA: getting gpu properties: looking up vram: executing nvidia-smi: exit status 6: No devices were found
ENGINE      VENDOR         DESCRIPTION                                   COMPAT
nvidia-gpu  Canonical Ltd  Optimized for inference on Nvidia GPUs, usi…  yes   
cpu         Canonical Ltd  Optimized for a range of CPU micro-architec…  yes   
amd-gpu     Canonical Ltd  Use ROCm for inference on AMD GPUs.           no
```

This PR changes the library to pass warnings to the caller, to be printed at the right time after stopping spinner.