### PR TITLE
Add `text:markdown` as webui capability

### DIFF
--- a/pkg/webui/config.go
+++ b/pkg/webui/config.go
@@ -14,12 +14,13 @@ type Config struct {
 }
 
 const (
-	capabilityText   string = "text"
-	capabilityVision string = "vision"
+	capabilityText         string = "text"
+	capabilityTextMarkdown string = "text:markdown"
+	capabilityVision       string = "vision"
 )
 
 func SupportedCapabilities() []string {
-	return []string{capabilityText, capabilityVision}
+	return []string{capabilityText, capabilityTextMarkdown, capabilityVision}
 }
 
 func (c Config) Validate() error {

--- a/snap/local/server-webui.sh
+++ b/snap/local/server-webui.sh
@@ -5,6 +5,6 @@ port="$(modelctl get webui.http.port)"
 host="$(modelctl get webui.http.host)"
 
 # The capabilities depend on the model and engine size
-capabilities="text, vision"
+capabilities="text, text:markdown, vision"
 
-exec modelctl serve-webui "$SNAP/etc/webui" --port "$port" --host "$host" --capabilities "$capabilities"
+exec modelctl serve-webui "$SNAP/webui" --port "$port" --host "$host" --capabilities "$capabilities"

--- a/snap/local/server.sh
+++ b/snap/local/server.sh
@@ -4,4 +4,4 @@ port="$(modelctl get http.port)"
 host="$(modelctl get http.host)"
 
 echo "Starting mock OpenAI server on $host:$port"
-exec "$SNAP"/bin/mock-openai-server/server.py --port "$port" --host "$host"
+exec "$SNAP"/bin/mock-openai-server/server.py --port "$port" --host "$host" --reasoning --delay 0.05

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -127,7 +127,7 @@ parts:
 
   webui:
     plugin: dump
-    source: https://github.com/canonical/inference-snaps-webui/releases/download/v1.0.0-beta.3/inference-snaps-webui.tar.xz
+    source: https://github.com/canonical/inference-snaps-webui/releases/download/v1.0.0-pr.24/inference-snaps-webui.tar.xz
     organize:
       "*": webui/
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -127,7 +127,7 @@ parts:
 
   webui:
     plugin: dump
-    source: https://github.com/canonical/inference-snaps-webui/releases/download/v1.0.0-pr.24/inference-snaps-webui.tar.xz
+    source: https://github.com/canonical/inference-snaps-webui/releases/download/v1.0.0-beta.5/inference-snaps-webui.tar.xz
     organize:
       "*": webui/
 

--- a/test_data/mock-openai-server/server.py
+++ b/test_data/mock-openai-server/server.py
@@ -42,13 +42,16 @@ def _models_payload():
     }
 
 
-_MOCK_REPLY = "Hello! I am a mock assistant. How can I help you today?"
+def _extract_last_user_message(request_json):
+    """Return the content of the last user message in the request, or a fallback."""
+    messages = request_json.get("messages", [])
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            return msg.get("content", "")
+    return ""
 
-# Words of the reply, emitted as individual SSE chunks to simulate streaming.
-_MOCK_REPLY_WORDS = _MOCK_REPLY.split(" ")
 
-
-def _chat_completion_payload():
+def _chat_completion_payload(reply):
     """Plain (non-streaming) chat.completion response."""
     return {
         "id": "chatcmpl-mock-0000000000000001",
@@ -60,7 +63,8 @@ def _chat_completion_payload():
                 "index": 0,
                 "message": {
                     "role": "assistant",
-                    "content": _MOCK_REPLY,
+                    "content": reply,
+                    "reasoning_content": reply,
                 },
                 "finish_reason": "stop",
                 "logprobs": None,
@@ -68,8 +72,8 @@ def _chat_completion_payload():
         ],
         "usage": {
             "prompt_tokens": 10,
-            "completion_tokens": 12,
-            "total_tokens": 22,
+            "completion_tokens": len(reply.split()),
+            "total_tokens": 10 + len(reply.split()),
         },
         "system_fingerprint": None,
     }
@@ -81,6 +85,7 @@ def _chat_completion_chunk(content, finish_reason=None, is_first=False):
     if is_first:
         delta["role"] = "assistant"
     delta["content"] = content
+    delta["reasoning_content"] = content
 
     return {
         "id": "chatcmpl-mock-0000000000000001",
@@ -99,12 +104,13 @@ def _chat_completion_chunk(content, finish_reason=None, is_first=False):
     }
 
 
-def _chat_completion_sse_chunks():
+def _chat_completion_sse_chunks(reply):
     """
     Yield SSE-formatted lines for a complete streaming chat response.
     Each item is a bytes object ready to be written to the socket.
     """
-    for i, word in enumerate(_MOCK_REPLY_WORDS):
+    words = reply.split(" ")
+    for i, word in enumerate(words):
         time.sleep(RESPONSE_DELAY)
         # Add a space before each word except the first
         token = word if i == 0 else " " + word
@@ -220,6 +226,8 @@ class MockOpenAIHandler(BaseHTTPRequestHandler):
         except json.JSONDecodeError:
             request_json = {}
 
+        reply = _extract_last_user_message(request_json)
+
         if request_json.get("stream", False):
             # Streaming response: Server-Sent Events (SSE) of ChatCompletionChunk
             self.send_response(200)
@@ -228,14 +236,14 @@ class MockOpenAIHandler(BaseHTTPRequestHandler):
             self.send_header("Cache-Control", "no-cache")
             self.end_headers()
             try:
-                for sse_line in _chat_completion_sse_chunks():
+                for sse_line in _chat_completion_sse_chunks(reply):
                     self.wfile.write(sse_line)
                 self.wfile.flush()
             except BrokenPipeError:
                 pass  # client disconnected mid-stream
         else:
             # Non-streaming response: plain application/json ChatCompletion
-            self._send_json(_chat_completion_payload())
+            self._send_json(_chat_completion_payload(reply))
 
 
 # ---------------------------------------------------------------------------

--- a/test_data/mock-openai-server/server.py
+++ b/test_data/mock-openai-server/server.py
@@ -20,6 +20,9 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 # Global delay in seconds applied before every response and between SSE chunks.
 RESPONSE_DELAY = 0.5
 
+# Delay in seconds before the first SSE chunk is sent (time to first token).
+TIME_TO_FIRST_TOKEN = 0.0
+
 # When True, responses include reasoning_content in addition to content.
 INCLUDE_REASONING = False
 
@@ -118,6 +121,10 @@ def _chat_completion_sse_chunks(reply):
     First emits all reasoning_content chunks, then all content chunks.
     """
     words = reply.split(" ")
+
+    # Time-to-first-token delay before any chunk is sent
+    if TIME_TO_FIRST_TOKEN > 0:
+        time.sleep(TIME_TO_FIRST_TOKEN)
 
     # Phase 1: reasoning_content chunks (only when reasoning is enabled)
     if INCLUDE_REASONING:
@@ -268,7 +275,7 @@ class MockOpenAIHandler(BaseHTTPRequestHandler):
 # ---------------------------------------------------------------------------
 
 def main():
-    global RESPONSE_DELAY, INCLUDE_REASONING
+    global RESPONSE_DELAY, TIME_TO_FIRST_TOKEN, INCLUDE_REASONING
 
     parser = argparse.ArgumentParser(
         description="Mock OpenAI-compatible HTTP API server for testing."
@@ -292,6 +299,13 @@ def main():
         help="Delay in seconds before each response and between SSE chunks (default: 0)",
     )
     parser.add_argument(
+        "--ttft",
+        type=float,
+        default=TIME_TO_FIRST_TOKEN,
+        metavar="SECONDS",
+        help="Delay in seconds before the first SSE chunk is sent, i.e. time to first token (default: 0)",
+    )
+    parser.add_argument(
         "--reasoning",
         action="store_true",
         default=False,
@@ -300,12 +314,14 @@ def main():
     args = parser.parse_args()
 
     RESPONSE_DELAY = args.delay
+    TIME_TO_FIRST_TOKEN = args.ttft
     INCLUDE_REASONING = args.reasoning
 
     server_address = (args.host, args.port)
     httpd = HTTPServer(server_address, MockOpenAIHandler)
     print(f"[mock-openai] Listening on http://{args.host}:{args.port}")
     print(f"[mock-openai] Response delay: {RESPONSE_DELAY}s")
+    print(f"[mock-openai] Time to first token: {TIME_TO_FIRST_TOKEN}s")
     print(f"[mock-openai] Reasoning: {'on' if INCLUDE_REASONING else 'off'}")
     print("[mock-openai] Serving /v1 and /v3 prefixes")
     print("[mock-openai] Endpoints:")

--- a/test_data/mock-openai-server/server.py
+++ b/test_data/mock-openai-server/server.py
@@ -20,6 +20,9 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 # Global delay in seconds applied before every response and between SSE chunks.
 RESPONSE_DELAY = 0.5
 
+# When True, responses include reasoning_content in addition to content.
+INCLUDE_REASONING = False
+
 
 # ---------------------------------------------------------------------------
 # Static response payloads
@@ -53,6 +56,12 @@ def _extract_last_user_message(request_json):
 
 def _chat_completion_payload(reply):
     """Plain (non-streaming) chat.completion response."""
+    message = {
+        "role": "assistant",
+        "content": reply,
+    }
+    if INCLUDE_REASONING:
+        message["reasoning_content"] = reply
     return {
         "id": "chatcmpl-mock-0000000000000001",
         "object": "chat.completion",
@@ -61,11 +70,7 @@ def _chat_completion_payload(reply):
         "choices": [
             {
                 "index": 0,
-                "message": {
-                    "role": "assistant",
-                    "content": reply,
-                    "reasoning_content": reply,
-                },
+                "message": message,
                 "finish_reason": "stop",
                 "logprobs": None,
             }
@@ -79,13 +84,15 @@ def _chat_completion_payload(reply):
     }
 
 
-def _chat_completion_chunk(content, finish_reason=None, is_first=False):
+def _chat_completion_chunk(content=None, reasoning_content=None, finish_reason=None, is_first=False):
     """Build a single ChatCompletionChunk payload."""
     delta = {}
     if is_first:
         delta["role"] = "assistant"
-    delta["content"] = content
-    delta["reasoning_content"] = content
+    if content is not None:
+        delta["content"] = content
+    if reasoning_content is not None:
+        delta["reasoning_content"] = reasoning_content
 
     return {
         "id": "chatcmpl-mock-0000000000000001",
@@ -108,18 +115,28 @@ def _chat_completion_sse_chunks(reply):
     """
     Yield SSE-formatted lines for a complete streaming chat response.
     Each item is a bytes object ready to be written to the socket.
+    First emits all reasoning_content chunks, then all content chunks.
     """
     words = reply.split(" ")
+
+    # Phase 1: reasoning_content chunks (only when reasoning is enabled)
+    if INCLUDE_REASONING:
+        for i, word in enumerate(words):
+            time.sleep(RESPONSE_DELAY)
+            token = word if i == 0 else " " + word
+            chunk = _chat_completion_chunk(reasoning_content=token, is_first=(i == 0))
+            yield f"data: {json.dumps(chunk)}\n\n".encode("utf-8")
+
+    # Phase 2: content chunks
     for i, word in enumerate(words):
         time.sleep(RESPONSE_DELAY)
-        # Add a space before each word except the first
         token = word if i == 0 else " " + word
-        chunk = _chat_completion_chunk(token, finish_reason=None, is_first=(i == 0))
+        chunk = _chat_completion_chunk(content=token, is_first=(i == 0 and not INCLUDE_REASONING))
         yield f"data: {json.dumps(chunk)}\n\n".encode("utf-8")
 
     # Final chunk: empty delta, finish_reason="stop"
     time.sleep(RESPONSE_DELAY)
-    stop_chunk = _chat_completion_chunk("", finish_reason="stop")
+    stop_chunk = _chat_completion_chunk(content="", finish_reason="stop")
     yield f"data: {json.dumps(stop_chunk)}\n\n".encode("utf-8")
 
     # SSE stream terminator
@@ -251,7 +268,7 @@ class MockOpenAIHandler(BaseHTTPRequestHandler):
 # ---------------------------------------------------------------------------
 
 def main():
-    global RESPONSE_DELAY
+    global RESPONSE_DELAY, INCLUDE_REASONING
 
     parser = argparse.ArgumentParser(
         description="Mock OpenAI-compatible HTTP API server for testing."
@@ -274,14 +291,22 @@ def main():
         metavar="SECONDS",
         help="Delay in seconds before each response and between SSE chunks (default: 0)",
     )
+    parser.add_argument(
+        "--reasoning",
+        action="store_true",
+        default=False,
+        help="Include reasoning_content in responses (default: off)",
+    )
     args = parser.parse_args()
 
     RESPONSE_DELAY = args.delay
+    INCLUDE_REASONING = args.reasoning
 
     server_address = (args.host, args.port)
     httpd = HTTPServer(server_address, MockOpenAIHandler)
     print(f"[mock-openai] Listening on http://{args.host}:{args.port}")
     print(f"[mock-openai] Response delay: {RESPONSE_DELAY}s")
+    print(f"[mock-openai] Reasoning: {'on' if INCLUDE_REASONING else 'off'}")
     print("[mock-openai] Serving /v1 and /v3 prefixes")
     print("[mock-openai] Endpoints:")
     print(f"  GET  http://{args.host}:{args.port}/v1/models")


### PR DESCRIPTION
This PR adds `text:markdown` as an accepted value for a webui capability.

The mock openai server is updated to respond with the same text as received in the prompt. The text is added to response field by default, but can also be added to the reasoning output if the `--reasoning` flag is set. This is useful for testing different formatting in the webui.

Run it like this:
```
$ python3 test_data/mock-openai-server/server.py --delay 0.05 --reasoning --ttft 5
```

Or use the `stack-utils` snap as is.