### PR TITLE
Make the FQDN configurable

### DIFF
--- a/cmd/cli/common/endpoints.go
+++ b/cmd/cli/common/endpoints.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+
+	"github.com/canonical/inference-snaps-cli/pkg/storage"
 )
 
 const (
@@ -61,9 +63,23 @@ func serverEndpoints(ctx *Context, settingsCollection []ComponentSettings) (map[
 
 func serverHttpUrl(ctx *Context, serverConfig map[string]string) (string, error) {
 	const (
+		confHttpFqdn    = "http.fqdn"
 		confHttpPort    = "http.port"
 		defaultBasePath = "/"
+		defaultFqdn     = "localhost"
 	)
+
+	httpFqdnMap, err := ctx.Config.Get(confHttpFqdn)
+	if err != nil {
+		return "", fmt.Errorf("getting config %q: %v", confHttpPort, err)
+	}
+	httpFqdn, found := httpFqdnMap[confHttpFqdn]
+	if !found {
+		httpFqdn = defaultFqdn
+		if err := ctx.Config.Set(confHttpFqdn, defaultFqdn, storage.PackageConfig); err != nil {
+			return "", fmt.Errorf("setting default config %q: %v", confHttpFqdn, err)
+		}
+	}
 
 	httpPortMap, err := ctx.Config.Get(confHttpPort)
 	if err != nil {
@@ -78,7 +94,7 @@ func serverHttpUrl(ctx *Context, serverConfig map[string]string) (string, error)
 
 	endpointUrl := url.URL{
 		Scheme: serverConfig[protocolKey],
-		Host:   fmt.Sprintf("localhost:%v", httpPort),
+		Host:   fmt.Sprintf("%s:%v", httpFqdn, httpPort),
 		Path:   basePath,
 	}
 

--- a/cmd/cli/common/endpoints_test.go
+++ b/cmd/cli/common/endpoints_test.go
@@ -108,11 +108,15 @@ func TestServerEndpoints(t *testing.T) {
 func TestServerHttpUrl(t *testing.T) {
 	testCases := []struct {
 		name         string
+		configValues map[string]any
 		serverConfig map[string]string
 		want         string
 	}{
 		{
 			name: "default base path",
+			configValues: map[string]any{
+				"http.port": "8080",
+			},
 			serverConfig: map[string]string{
 				"protocol": "http",
 			},
@@ -120,6 +124,9 @@ func TestServerHttpUrl(t *testing.T) {
 		},
 		{
 			name: "custom base path",
+			configValues: map[string]any{
+				"http.port": "8080",
+			},
 			serverConfig: map[string]string{
 				"protocol":  "http",
 				"base-path": "/v1",
@@ -128,18 +135,34 @@ func TestServerHttpUrl(t *testing.T) {
 		},
 		{
 			name: "https protocol",
+			configValues: map[string]any{
+				"http.port": "8080",
+			},
 			serverConfig: map[string]string{
 				"protocol":  "https",
 				"base-path": "/v3",
 			},
 			want: "https://localhost:8080/v3",
 		},
+		{
+			name: "configured fqdn",
+			configValues: map[string]any{
+				"http.port": "8080",
+				"http.fqdn": "inference.example.com",
+			},
+			serverConfig: map[string]string{
+				"protocol":  "http",
+				"base-path": "/v1",
+			},
+			want: "http://inference.example.com:8080/v1",
+		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			config := storage.NewMockConfig(testCase.configValues)
 			ctx := &Context{
-				Config: storage.NewMockConfig(map[string]any{"http.port": "8080"}),
+				Config: config,
 			}
 
 			got, err := serverHttpUrl(ctx, testCase.serverConfig)


### PR DESCRIPTION
The OpenAI Base URL that is passed to the Web UI uses a hardcoded `localhost` host name. This breaks the Web UI when it is browsed on a different machine.

This PR replaces the hardcoded host name with a configurable fully qualified domain name (FQDN). To set it, the user would run `sudo <snap> set http.fqdn=<domain>`, where domain could be a .local hostname, an IP address, or a public domain name.


If `fqdn` is not set during installation, the CLI sets it to `localhost`. The same thing could be done with any generic configuration such as `host`, `verbose`, to avoid having to set it on install and refresh.

```console
$ stack-utils status
engine: intel-cpu
services:
    server: active
    server-webui: inactive
endpoints:
    kserve: http://localhost:8322/2
    openai: http://localhost:8322/v3
    openvino: http://localhost:8322/v1
    webui: http://localhost:8323/

$ stack-utils get
http.fqdn: localhost
http.host: 127.0.0.1
http.port: 8322
verbose: 3
webui.http.host: 127.0.0.1
webui.http.port: 8323

$ sudo stack-utils set http.fqdn=test
Restart stack-utils to apply the changes? [Y/n] Y

$ stack-utils status
engine: intel-cpu
services:
    server: active
    server-webui: inactive
endpoints:
    kserve: http://test:8322/2
    openai: http://test:8322/v3
    openvino: http://test:8322/v1
    webui: http://localhost:8323/

$ curl -s http://localhost:8323/config | jq
{
  "openAIBaseURL": "http://test:8322/v3",
  "capabilities": [
    "text",
    "vision"
  ],
  "instanceName": "stack-utils",
  "engineName": "intel-cpu"
}
```