### PR TITLE
Add check for no active engine in prune-cache

### DIFF
--- a/cmd/cli/commands/prune-cache.go
+++ b/cmd/cli/commands/prune-cache.go
@@ -47,7 +47,10 @@ func (cmd *pruneCacheCommand) run(_ *cobra.Command, _ []string) error {
 	activeEngine, err := cmd.Cache.GetActiveEngine()
 	if err != nil {
 		return fmt.Errorf("%s: %w", common.LookingUpActiveEngine, err)
+	} else if activeEngine == "" {
+		return common.ErrNoActiveEngine
 	}
+
 	activeEngineManifest, err := engines.LoadManifest(cmd.EnginesDir, activeEngine)
 	if err != nil {
 		if errors.Is(err, engines.ErrManifestNotFound) {

--- a/cmd/cli/commands/serve-webui.go
+++ b/cmd/cli/commands/serve-webui.go
@@ -59,7 +59,7 @@ func (cmd *serveWebUiCommand) serveWebUi(_ *cobra.Command, args []string) error 
 		return fmt.Errorf("getting active engine: %v", err)
 	}
 	if activeEngineName == "" {
-		return fmt.Errorf("no engine is active")
+		return common.ErrNoActiveEngine
 	}
 
 	var capabilities []string


### PR DESCRIPTION
The `prune-cache` command previously failed to distinguish between two distinct failure states, leading to ambiguous feedback. This update implements specific checks to differentiate between them:

- No active engine: Handles cases where no engine is currently set as active.
- Manifest load error: Handles cases where an active engine exists but its manifest fails to load.

Closes https://github.com/canonical/inference-snaps/issues/264