### PR TITLE
Restart prompt when switching engine

### DIFF
--- a/cmd/cli/commands/set.go
+++ b/cmd/cli/commands/set.go
@@ -121,8 +121,8 @@ func (cmd *setCommand) setUserConfigs(keyValues map[string]string) error {
 
 	// Restart if configurations were changed
 	if anyChange {
-		if err := cmd.restartToApply(); err != nil {
-			return err
+		if !cmd.noRestart {
+			return common.PromptRestartToApplyChanges(cmd.Context, cmd.assumeYes)
 		}
 	}
 
@@ -184,12 +184,7 @@ func (cmd *setCommand) getCurrentValue(key string) (string, bool, error) {
 
 func (cmd *setCommand) restartToApply() error {
 	if !cmd.noRestart {
-		msg := fmt.Sprintf("Restart %s to apply the changes?", cmd.Snap.InstanceName())
-		if cmd.assumeYes || common.PromptYN(msg, true) {
-			if err := cmd.Snap.Restart(); err != nil {
-				return fmt.Errorf("restarting snap: %v", err)
-			}
-		}
+		return common.PromptRestartToApplyChanges(cmd.Context, cmd.assumeYes)
 	}
 	return nil
 }

--- a/cmd/cli/commands/set_test.go
+++ b/cmd/cli/commands/set_test.go
@@ -345,7 +345,7 @@ func ExampleSet_noRestartWhenFinalValueUnchanged() {
 	// Output:
 }
 
-func ExampleSet_restartWhenFinalValueUnchanged() {
+func ExampleSet_restartWhenFinalValueChanged() {
 	config := storage.NewMockConfig()
 	config.Set("api.port", "8080", storage.UserConfig)
 	cmd := setCommand{

--- a/cmd/cli/commands/unset.go
+++ b/cmd/cli/commands/unset.go
@@ -72,12 +72,7 @@ func (cmd *unsetCommand) unsetValue(key string) error {
 	}
 
 	if !cmd.noRestart {
-		msg := fmt.Sprintf("Restart %s to apply the changes?", cmd.Snap.InstanceName())
-		if cmd.assumeYes || common.PromptYN(msg, true) {
-			if err := cmd.Snap.Restart(); err != nil {
-				return fmt.Errorf("restarting snap: %v", err)
-			}
-		}
+		return common.PromptRestartToApplyChanges(cmd.Context, cmd.assumeYes)
 	}
 	return nil
 }

--- a/cmd/cli/commands/unset_test.go
+++ b/cmd/cli/commands/unset_test.go
@@ -89,3 +89,42 @@ func TestUnsetNonexistentKey(t *testing.T) {
 		t.Fatalf("expected error message %q, got %q", expectedErrMsg, err.Error())
 	}
 }
+
+func ExampleUnset_noRestartWhenFinalValueUnchanged() {
+	config := storage.NewMockConfig()
+	config.Set("api.port", "8080", storage.PackageConfig)
+	config.Set("api.port", "8080", storage.UserConfig) // same as package value
+	cmd := unsetCommand{
+		assumeYes: true,
+		Context: &common.Context{
+			Config: config,
+			Snap:   snap.Mock(),
+		},
+	}
+
+	if err := cmd.unsetValue("api.port"); err != nil {
+		panic(err)
+	}
+
+	// Output:
+}
+
+func ExampleUnset_restartWhenFinalValueChanged() {
+	config := storage.NewMockConfig()
+	config.Set("api.port", "8080", storage.PackageConfig)
+	config.Set("api.port", "9999", storage.UserConfig)
+	cmd := unsetCommand{
+		assumeYes: true,
+		Context: &common.Context{
+			Config: config,
+			Snap:   snap.Mock(),
+		},
+	}
+
+	if err := cmd.unsetValue("api.port"); err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// [mock] Restarting all services
+}

--- a/cmd/cli/commands/use-engine.go
+++ b/cmd/cli/commands/use-engine.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/canonical/go-snapctl"
-	"github.com/canonical/go-snapctl/env"
 	"github.com/canonical/inference-snaps-cli/cmd/cli/common"
 	"github.com/canonical/inference-snaps-cli/pkg/engines"
 	"github.com/canonical/inference-snaps-cli/pkg/selector"
@@ -24,6 +23,7 @@ type useEngineCommand struct {
 	auto      bool
 	fix       bool
 	assumeYes bool
+	noRestart bool
 }
 
 func UseEngine(ctx *common.Context) *cobra.Command {
@@ -44,7 +44,8 @@ func UseEngine(ctx *common.Context) *cobra.Command {
 	// flags
 	cobraCmd.Flags().BoolVar(&cmd.auto, "auto", false, "automatically select a compatible engine")
 	cobraCmd.Flags().BoolVar(&cmd.fix, "fix", false, "fix issues with the currently active engine")
-	cobraCmd.Flags().BoolVar(&cmd.assumeYes, "assume-yes", false, "assume yes for downloading new components")
+	cobraCmd.Flags().BoolVar(&cmd.assumeYes, "assume-yes", false, "assume yes for all prompts")
+	cobraCmd.Flags().BoolVar(&cmd.noRestart, "no-restart", false, "do not restart the snap after changing engine")
 
 	return cobraCmd
 }
@@ -179,14 +180,13 @@ func (cmd *useEngineCommand) switchEngine(engineName string) error {
 
 	fmt.Printf("Engine changed to %q.\n", engineName)
 
-	// TODO: get this from an env var instead (e.g. ENGINE_SERVICES=server,proxy)
-	serviceName := env.SnapInstanceName() + ".server"
-
 	// Currently we cannot reliably determine if the service is active to automatically restart it
 	// See https://bugs.launchpad.net/snapd/+bug/2137543
 	//
-	// Ask the user to restart the service manually
-	fmt.Printf("\nRun \"snap restart %s\" to use the new engine.\n", serviceName)
+	// Ask if the user wants to restart
+	if !cmd.noRestart {
+		return common.PromptRestartToApplyChanges(cmd.Context, cmd.assumeYes)
+	}
 
 	return nil
 }

--- a/cmd/cli/commands/use-engine_test.go
+++ b/cmd/cli/commands/use-engine_test.go
@@ -1,0 +1,51 @@
+package commands
+
+import (
+	"github.com/canonical/inference-snaps-cli/cmd/cli/common"
+	"github.com/canonical/inference-snaps-cli/pkg/snap"
+	"github.com/canonical/inference-snaps-cli/pkg/storage"
+)
+
+func ExampleUseEngine_noRestartWhenEngineUnchanged() {
+	cache := storage.NewMockCache()
+	cache.SetActiveEngine("intel-gpu")
+	config := storage.NewMockConfig()
+	cmd := useEngineCommand{
+		assumeYes: true,
+		Context: &common.Context{
+			EnginesDir: "../../../test_data/engines",
+			Cache:      cache,
+			Config:     config,
+			Snap:       snap.Mock(),
+		},
+	}
+
+	if err := cmd.switchEngine("intel-gpu"); err != nil {
+		panic(err)
+	}
+
+	// Output:
+}
+
+func ExampleUseEngine_restartWhenEngineChanged() {
+	cache := storage.NewMockCache()
+	cache.SetActiveEngine("intel-gpu")
+	config := storage.NewMockConfig()
+	cmd := useEngineCommand{
+		assumeYes: true,
+		Context: &common.Context{
+			EnginesDir: "../../../test_data/engines",
+			Cache:      cache,
+			Config:     config,
+			Snap:       snap.Mock(),
+		},
+	}
+
+	if err := cmd.switchEngine("cpu-avx1"); err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// Engine changed to "cpu-avx1".
+	// [mock] Restarting all services
+}

--- a/cmd/cli/common/prompt.go
+++ b/cmd/cli/common/prompt.go
@@ -52,3 +52,13 @@ func PromptlnEnter(action string) bool {
 
 	return true
 }
+
+func PromptRestartToApplyChanges(ctx *Context, assumeYes bool) error {
+	msg := fmt.Sprintf("Restart %s to apply the changes?", ctx.Snap.InstanceName())
+	if assumeYes || PromptYN(msg, true) {
+		if err := ctx.Snap.Restart(); err != nil {
+			return fmt.Errorf("restarting snap: %v", err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
When switching engines, a printout suggests restarting the "server". This is fragile as it assumes there is just one service that needs to be restarted, and that the service is named "server". If the snap also contains the webui, then the web server also needs to be restarted in order for the new configuration to take effect.

This PR drops the service name, defaulting to restart all services. The suggestion is replaced with a prompt similar to what is used by set and unset commands.

```console
$ date
Thu 30 Apr 2026 11:38:22 AM CEST

$ sudo gemma4 use-engine cpu
Engine changed to "cpu".
Restart gemma4 to apply the changes? [Y/n] Y

# It has restarted
$ sudo snap logs gemma4
2026-04-30T11:38:56+02:00 gemma4.server[97650]: print_info: MASK token            = 4 '<mask>'
...

$ sudo gemma4 use-engine nvidia-gpu 
Engine changed to "nvidia-gpu".
Restart gemma4 to apply the changes? [Y/n] n

# NOT restarted
$ sudo snap logs gemma4
2026-04-30T11:38:58+02:00 gemma4.server[97650]: Hi there<turn|>
...

# No change, no restart prompt
$ sudo gemma4 use-engine nvidia-gpu

$ sudo gemma4 use-engine cpu --no-restart 
Engine changed to "cpu".

$ sudo gemma4 use-engine nvidia-gpu --assume-yes 
Engine changed to "nvidia-gpu".

# It has restarted
$ sudo snap logs gemma4
2026-04-30T11:41:29+02:00 gemma4.server[99141]: main: n_parallel is set to auto, using n_parallel = 4 and kv_unified = true
...

$ gemma4 version
snap: e4b+422ce40
cli: v1.0.0-beta.47.0.20260430092731-1f7062f3ad32+dirty
```