### PR TITLE
Fix refresh when there is no active engine

### DIFF
--- a/cmd/cli/commands/use-engine.go
+++ b/cmd/cli/commands/use-engine.go
@@ -79,7 +79,12 @@ func (cmd *useEngineCommand) run(_ *cobra.Command, args []string) error {
 		if len(args) != 0 {
 			return fmt.Errorf("cannot specify both engine name and --fix flag")
 		}
-		return cmd.fixActiveEngine()
+		// If no engine is active, there's nothing to fix.
+		err := cmd.fixActiveEngine()
+		if errors.Is(err, common.ErrNoActiveEngine) {
+			return nil
+		}
+		return err
 	} else {
 		if len(args) == 1 {
 			return cmd.switchEngine(args[0])

--- a/cmd/cli/commands/use-engine_test.go
+++ b/cmd/cli/commands/use-engine_test.go
@@ -65,6 +65,6 @@ func TestFixActiveEngine_noActiveEngine(t *testing.T) {
 
 	err := cmd.fixActiveEngine()
 	if !errors.Is(err, common.ErrNoActiveEngine) {
-		t.Errorf("expected ErrNoActiveEngine, got %v", err)
+		t.Errorf("expected no active engine error, got %v", err)
 	}
 }

--- a/cmd/cli/commands/use-engine_test.go
+++ b/cmd/cli/commands/use-engine_test.go
@@ -1,6 +1,9 @@
 package commands
 
 import (
+	"errors"
+	"testing"
+
 	"github.com/canonical/inference-snaps-cli/cmd/cli/common"
 	"github.com/canonical/inference-snaps-cli/pkg/snap"
 	"github.com/canonical/inference-snaps-cli/pkg/storage"
@@ -48,4 +51,20 @@ func ExampleUseEngine_restartWhenEngineChanged() {
 	// Output:
 	// Engine changed to "cpu-avx1".
 	// [mock] Restarting all services
+}
+
+func TestFixActiveEngine_noActiveEngine(t *testing.T) {
+	cache := storage.NewMockCache()
+	cmd := useEngineCommand{
+		Context: &common.Context{
+			EnginesDir: "../../../test_data/engines",
+			Cache:      cache,
+			Snap:       snap.Mock(),
+		},
+	}
+
+	err := cmd.fixActiveEngine()
+	if !errors.Is(err, common.ErrNoActiveEngine) {
+		t.Errorf("expected ErrNoActiveEngine, got %v", err)
+	}
 }


### PR DESCRIPTION
This PR addresses an issue where the post-refresh hook fails under specific conditions, blocking the refresh process.

Currently, if a snap lacks auto-connection permissions or is installed locally, the use-engine command invoked during the post-refresh hook fails because it cannot locate an active engine.

Modified the `use-engine` command invoked with  `--fix` flag to handle cases where cli cannot find an active engine implementing a silent failure mechanism for this specific command, ensuring that the hook continues execution even if there is no active engine