### PR TITLE
Report model name in status

### DIFF
--- a/cmd/cli/commands/status.go
+++ b/cmd/cli/commands/status.go
@@ -108,6 +108,7 @@ type status struct {
 	Engine    string            `json:"engine" yaml:"engine"`
 	Services  map[string]string `json:"services" yaml:"services"`
 	Endpoints map[string]string `json:"endpoints,omitempty" yaml:"endpoints,omitempty"`
+	Model     map[string]string `json:"model,omitempty" yaml:"model,omitempty"`
 }
 
 func (cmd *statusCommand) statusStruct() (*status, error) {
@@ -133,6 +134,12 @@ func (cmd *statusCommand) statusStruct() (*status, error) {
 		return nil, fmt.Errorf("getting server api endpoints: %v", err)
 	}
 	statusStr.Endpoints = endpoints
+
+	modelStatus, err := common.ModelStatus(cmd.Context)
+	if err != nil {
+		return nil, fmt.Errorf("getting model status: %v", err)
+	}
+	statusStr.Model = modelStatus
 
 	return &statusStr, nil
 }

--- a/cmd/cli/common/model_status.go
+++ b/cmd/cli/common/model_status.go
@@ -1,0 +1,35 @@
+package common
+
+import (
+	"fmt"
+	"strings"
+)
+
+func ModelStatus(ctx *Context) (map[string]string, error) {
+	settings, err := EngineComponentSettings(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading engine environment: %v", err)
+	}
+	return modelStatus(settings)
+}
+
+func modelStatus(settingsCollection []ComponentSettings) (map[string]string, error) {
+	status := make(map[string]string)
+	for _, settings := range settingsCollection {
+		for i := range settings.Environment {
+			// Split into key/value
+			kv := settings.Environment[i]
+			parts := strings.SplitN(kv, "=", 2)
+			if len(parts) != 2 {
+				return status, fmt.Errorf("invalid env var %q", kv)
+			}
+			k, v := parts[0], parts[1]
+
+			if k == "MODEL_NAME" {
+				status["name"] = v
+			}
+		}
+	}
+
+	return status, nil
+}

--- a/cmd/cli/common/model_status_test.go
+++ b/cmd/cli/common/model_status_test.go
@@ -1,0 +1,100 @@
+package common
+
+import (
+	"testing"
+)
+
+func TestModelStatus_NoComponents(t *testing.T) {
+	status, err := modelStatus([]ComponentSettings{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(status) != 0 {
+		t.Errorf("expected empty status, got: %v", status)
+	}
+}
+
+func TestModelStatus_ModelNamePresent(t *testing.T) {
+	settings := []ComponentSettings{
+		{
+			Environment: []string{
+				"MODEL_NAME=my-model",
+				"OTHER_VAR=value",
+			},
+		},
+	}
+
+	status, err := modelStatus(settings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status["name"] != "my-model" {
+		t.Errorf("expected name %q, got %q", "my-model", status["name"])
+	}
+}
+
+func TestModelStatus_NoModelName(t *testing.T) {
+	settings := []ComponentSettings{
+		{
+			Environment: []string{
+				"OTHER_VAR=value",
+			},
+		},
+	}
+
+	status, err := modelStatus(settings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := status["name"]; ok {
+		t.Errorf("expected no 'name' key, but got: %q", status["name"])
+	}
+}
+
+func TestModelStatus_MultipleComponents_LastWins(t *testing.T) {
+	settings := []ComponentSettings{
+		{
+			Environment: []string{"MODEL_NAME=first-model"},
+		},
+		{
+			Environment: []string{"MODEL_NAME=second-model"},
+		},
+	}
+
+	status, err := modelStatus(settings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status["name"] != "second-model" {
+		t.Errorf("expected name %q, got %q", "second-model", status["name"])
+	}
+}
+
+func TestModelStatus_InvalidEnvVar(t *testing.T) {
+	settings := []ComponentSettings{
+		{
+			Environment: []string{"INVALID_NO_EQUALS"},
+		},
+	}
+
+	_, err := modelStatus(settings)
+	if err == nil {
+		t.Fatal("expected error for invalid env var, got nil")
+	}
+}
+
+func TestModelStatus_ModelNameWithEqualsInValue(t *testing.T) {
+	settings := []ComponentSettings{
+		{
+			Environment: []string{"MODEL_NAME=my=model"},
+		},
+	}
+
+	status, err := modelStatus(settings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status["name"] != "my=model" {
+		t.Errorf("expected name %q, got %q", "my=model", status["name"])
+	}
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -91,6 +91,9 @@ parts:
     plugin: nil
     override-prime: |
       cat <<EOF > "$CRAFT_COMPONENT_DUMMY_COMPONENT_1_PRIME/component.yaml"
+      environment:
+        - MODEL_PATH=\$COMPONENT
+        - MODEL_NAME=gemma-3-4b-it-ov-int4-fq
       servers:
         openvino:
           protocol: http


### PR DESCRIPTION
Source the model name from the env vars exported in the component.yaml files. If it is set, report the model name in the status yaml.

```
$ stack-utils status
engine: intel-cpu
services:
    server: active
    server-webui: active
endpoints:
    kserve: http://localhost:8322/2
    openai: http://localhost:8322/v3
    openvino: http://localhost:8322/v1
    webui: http://localhost:8323/
model:
    name: gemma-3-4b-it-ov-int4-fq
```

Or if no model name is set in the component yamls:
```
$ stack-utils status
engine: cpu-avx1
services:
    server: active
    server-webui: inactive
```