### PR TITLE
Print warnings on verbose logging only

### DIFF
--- a/cmd/cli/commands/show-machine.go
+++ b/cmd/cli/commands/show-machine.go
@@ -88,7 +88,7 @@ func (cmd *showMachineCommand) fetchMachineInfoWithSpinner() (*types.HwInfo, err
 	hwInfo, warnings, err := hardware_info.Get(true)
 	stopProgress()
 
-	if len(warnings) > 0 {
+	if len(warnings) > 0 && cmd.Verbose {
 		for _, warning := range warnings {
 			fmt.Fprintf(os.Stderr, "Warning: %s\n", warning)
 		}

--- a/cmd/cli/common/engine.go
+++ b/cmd/cli/common/engine.go
@@ -154,7 +154,9 @@ func LoadEngineEnvironment(ctx *Context) (func(), error) {
 	err = loadEngineEnvironmentFromSettingsCollection(settingsCollection)
 	return func() {
 		if err := unloadEngineEnvironmentFromSettingsCollection(settingsCollection); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to unload engine environment: %v\n", err)
+			if ctx.Verbose {
+				fmt.Fprintf(os.Stderr, "Warning: failed to unload engine environment: %v\n", err)
+			}
 		}
 	}, err
 }
@@ -184,7 +186,9 @@ func UnsetEngineConfig(engineName string, unsetUserOverrides bool, ctx *Context)
 			if errors.Is(err, engines.ErrManifestNotFound) {
 				// TODO: remove this when implementing per-engine configuration
 				// We can't know what user overrides were set if the manifest is missing
-				fmt.Fprintf(os.Stderr, "Warning: previously active engine %q not found; skipping user configuration cleanup.\n", engineName)
+				if ctx.Verbose {
+					fmt.Fprintf(os.Stderr, "Warning: previously active engine %q not found; skipping user configuration cleanup.\n", engineName)
+				}
 				return nil
 			}
 			return fmt.Errorf("loading engine manifest: %v", err)
@@ -234,7 +238,7 @@ func ScoreEnginesWithSpinner(ctx *Context) ([]engines.ScoredManifest, error) {
 	scoredEngines, warnings, err := ScoreEngines(ctx)
 	stopProgress()
 
-	if len(warnings) > 0 {
+	if len(warnings) > 0 && ctx.Verbose {
 		for _, warning := range warnings {
 			fmt.Fprintf(os.Stderr, "Warning: %s\n", warning)
 		}


### PR DESCRIPTION
```console
$ stack-utils list-engines --verbose 
Verbose output enabled globally.
Warning: unable to get additional properties for pci device: Intel: getting gpu properties: looking up vram: clinfo: no devices found
Warning: unable to get additional properties for pci device: NVIDIA: getting gpu properties: looking up vram: executing nvidia-smi: exit status 6: No devices were found
ENGINE                 VENDOR             DESCRIPTION                    COMPAT
intel-gpu              Intel Corporation  Modern Intel GPUs (>=gen 13)   yes   
example-memory         Canonical Ltd      Legacy CPUs, offering full a…  yes   
intel-cpu              Intel Corporation  Use Intel CPUs                 yes   
cpu-avx2               Canonical Ltd      CPUs with AVX2                 yes   
cpu-avx1               Canonical Ltd      Legacy CPUs with only SSE4.2…  yes   
cpu                    Canonical Ltd      General CPU engine             yes   
cpu-devel              Canonical Ltd      Requires any CPU but is grad…  devel 
rocm-generic           Canonical Ltd      AMD GPUs using ROCm. All maj…  no    
not-compatible-engine  Canonical Ltd      This test engine is designed…  no    
intel-npu              Intel Corporation  Intel NPUs                     no    
ampere                 Canonical Ltd      Test ampere selection          no    
ampere-altra           Canonical Ltd      Test ampere selection          no    
arm-neon               Canonical Ltd      ARM CPUs with NEON instructi…  no    
cuda-generic           Canonical Ltd      Nvidia GPUs using CUDA. All …  no    
cpu-avx512             Canonical Ltd      CPUs with AVX512               no    
amd-gpu                Canonical Ltd      AMD specific engine targetin…  no    
$ stack-utils list-engines 
ENGINE                 VENDOR             DESCRIPTION                    COMPAT
intel-gpu              Intel Corporation  Modern Intel GPUs (>=gen 13)   yes   
example-memory         Canonical Ltd      Legacy CPUs, offering full a…  yes   
intel-cpu              Intel Corporation  Use Intel CPUs                 yes   
cpu-avx2               Canonical Ltd      CPUs with AVX2                 yes   
cpu-avx1               Canonical Ltd      Legacy CPUs with only SSE4.2…  yes   
cpu                    Canonical Ltd      General CPU engine             yes   
cpu-devel              Canonical Ltd      Requires any CPU but is grad…  devel 
rocm-generic           Canonical Ltd      AMD GPUs using ROCm. All maj…  no    
not-compatible-engine  Canonical Ltd      This test engine is designed…  no    
intel-npu              Intel Corporation  Intel NPUs                     no    
ampere                 Canonical Ltd      Test ampere selection          no    
ampere-altra           Canonical Ltd      Test ampere selection          no    
arm-neon               Canonical Ltd      ARM CPUs with NEON instructi…  no    
cuda-generic           Canonical Ltd      Nvidia GPUs using CUDA. All …  no    
cpu-avx512             Canonical Ltd      CPUs with AVX512               no    
amd-gpu                Canonical Ltd      AMD specific engine targetin…  no   
```


```console
$ stack-utils show-machine --verbose 
Verbose output enabled globally.
Warning: unable to get additional properties for pci device: Intel: getting gpu properties: looking up vram: clinfo: no devices found
Warning: unable to get additional properties for pci device: NVIDIA: getting gpu properties: looking up vram: executing nvidia-smi: exit status 6: No devices were found
cpus:
...

$ stack-utils show-machine
cpus:
```