### PR TITLE
Shorten environment passthrough config prefix

### DIFF
--- a/cmd/cli/commands/run.go
+++ b/cmd/cli/commands/run.go
@@ -64,8 +64,8 @@ func (cmd *runCommand) run(_ *cobra.Command, args []string) error {
 	// TODO: add signal handling to intercept SIGTERM and invoke clean() before exiting.
 	defer clean()
 
-	if err := cmd.processPassthroughConfigs(); err != nil {
-		return fmt.Errorf("processing passthrough configs: %v", err)
+	if err := cmd.processEnvConfigs(); err != nil {
+		return fmt.Errorf("processing env configs: %v", err)
 	}
 
 	command := args[0]
@@ -76,31 +76,21 @@ func (cmd *runCommand) run(_ *cobra.Command, args []string) error {
 	return execCmd.Run()
 }
 
-func (cmd *runCommand) getEnvVarsFromPassthroughConfigs(envVars map[string]any) (map[string]any, error) {
-	result := make(map[string]any)
-	const keyPrefix = "passthrough.environment."
-	for k, v := range envVars {
-		if strings.HasPrefix(k, keyPrefix) {
-			envVarName := strings.TrimPrefix(k, keyPrefix)
-			envVarValue := fmt.Sprintf("%v", v)
-			// Convert passthrough keys (my-key) to environment variables names (MY_KEY)
-			envVarName = strings.ToUpper(strings.ReplaceAll(envVarName, "-", "_"))
-			result[envVarName] = envVarValue
-		}
-	}
-
-	return result, nil
-}
-
-func (cmd *runCommand) processPassthroughConfigs() error {
-	passthroughConfigs, err := cmd.Config.Get("passthrough")
+func (cmd *runCommand) processEnvConfigs() error {
+	envConfigs, err := cmd.Config.Get("env")
 	if err != nil {
 		return fmt.Errorf("getting configs: %v", err)
 	}
-	envVars, err := cmd.getEnvVarsFromPassthroughConfigs(passthroughConfigs)
-	if err != nil {
-		return err
+
+	const keyPrefix = "env."
+	envVars := make(map[string]any, len(envConfigs))
+	for k, v := range envConfigs {
+		// Convert env keys (my-key) to environment variable names (MY_KEY)
+		name := strings.TrimPrefix(k, keyPrefix)
+		name = strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
+		envVars[name] = fmt.Sprintf("%v", v)
 	}
+
 	err = utils.SetEnvironmentVariables(envVars)
 	if err != nil {
 		return fmt.Errorf("setting environment variables: %v", err)

--- a/cmd/cli/commands/run_test.go
+++ b/cmd/cli/commands/run_test.go
@@ -8,46 +8,20 @@ import (
 	"github.com/canonical/inference-snaps-cli/pkg/storage"
 )
 
-func TestGetEnvVarsFromPassthroughConfigs(t *testing.T) {
-	cmd := runCommand{}
-	passthrough := map[string]any{
-		"passthrough.environment.my-key": "value",
-		"passthrough.environment.other":  123,
-		"passthrough.not-environment":    "ignored",
-	}
-
-	got, err := cmd.getEnvVarsFromPassthroughConfigs(passthrough)
-	if err != nil {
-		t.Fatalf("getEnvVarsFromPassthroughConfigs returned error: %v", err)
-	}
-
-	if len(got) != 2 {
-		t.Fatalf("getEnvVarsFromPassthroughConfigs returned %d keys, want 2", len(got))
-	}
-
-	if got["MY_KEY"] != "value" {
-		t.Fatalf("getEnvVarsFromPassthroughConfigs returned %v for MY_KEY, want value", got["MY_KEY"])
-	}
-
-	if got["OTHER"] != "123" {
-		t.Fatalf("getEnvVarsFromPassthroughConfigs returned %v for OTHER, want 123", got["OTHER"])
-	}
-}
-
-func TestProcessPassthroughConfigs(t *testing.T) {
+func TestProcessEnvConfigs(t *testing.T) {
 	mockConfig := storage.NewMockConfig()
-	mockConfig.Set("passthrough.environment.my-key", "value", storage.UserConfig)
-	mockConfig.Set("passthrough.environment.other", "123", storage.UserConfig)
-	mockConfig.Set("passthrough.not-environment", "ignored", storage.UserConfig)
+	mockConfig.Set("env.my-key", "value", storage.UserConfig)
+	mockConfig.Set("env.other", "123", storage.UserConfig)
+	mockConfig.Set("other.ignored", "ignored", storage.UserConfig)
 	cmd := runCommand{
 		Context: &common.Context{
 			Config: mockConfig,
 		},
 	}
 
-	err := cmd.processPassthroughConfigs()
+	err := cmd.processEnvConfigs()
 	if err != nil {
-		t.Fatalf("processPassthroughConfigs returned error: %v", err)
+		t.Fatalf("processEnvConfigs returned error: %v", err)
 	}
 
 	if got := os.Getenv("MY_KEY"); got != "value" {

--- a/cmd/cli/commands/set.go
+++ b/cmd/cli/commands/set.go
@@ -113,7 +113,7 @@ func (cmd *setCommand) setUserConfigs(keyValues map[string]string) error {
 			return fmt.Errorf("setting %q to %q: %v", k, v, err)
 		}
 
-		// User keys are known, except for passthrough keys
+		// User keys are known, except for env keys
 		if !currentKnown[k] || currentValues[k] != v {
 			anyChange = true
 		}
@@ -171,7 +171,7 @@ func (cmd *setCommand) getCurrentValue(key string) (string, bool, error) {
 		return "", false, fmt.Errorf("checking existing keys: %s", err)
 	}
 	currVal, found := currValMap[key]
-	if !found && !strings.HasPrefix(key, "passthrough.") {
+	if !found && !strings.HasPrefix(key, "env.") {
 		return "", false, fmt.Errorf("key %q is not found\n\n%s", key, common.SuggestKeyNotFound(key))
 	}
 

--- a/cmd/cli/commands/set_test.go
+++ b/cmd/cli/commands/set_test.go
@@ -241,7 +241,7 @@ func TestSetValuesRejectsUnknownKeysAtomically(t *testing.T) {
 	}
 }
 
-func TestSetAcceptsUnknownPassthroughKeys(t *testing.T) {
+func TestSetAcceptsUnknownEnvKeys(t *testing.T) {
 	config := storage.NewMockConfig()
 	cmd := setCommand{
 		noRestart: true,
@@ -251,18 +251,18 @@ func TestSetAcceptsUnknownPassthroughKeys(t *testing.T) {
 		},
 	}
 
-	err := cmd.setUserConfigs(map[string]string{"passthrough.custom-key": "custom-value"})
+	err := cmd.setUserConfigs(map[string]string{"env.custom-key": "custom-value"})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	values, err := config.Get("passthrough.custom-key")
+	values, err := config.Get("env.custom-key")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if value, found := values["passthrough.custom-key"]; !found || value != "custom-value" {
-		t.Fatalf("expected passthrough.custom-key to be set to custom-value, got %#v", values)
+	if value, found := values["env.custom-key"]; !found || value != "custom-value" {
+		t.Fatalf("expected env.custom-key to be set to custom-value, got %#v", values)
 	}
 }
 


### PR DESCRIPTION
The prefix to set environment variables configurations has been simplified from `passthrough.environment.` to `env.`.