### PR TITLE
Set minimum width for ENGINE and VENDOR columns

### DIFF
--- a/cmd/cli/commands/list-engines.go
+++ b/cmd/cli/commands/list-engines.go
@@ -124,8 +124,8 @@ func (cmd *listEnginesCommand) getEnginesTable(enginesList outputEngines) (strin
 		}
 
 		// Find max name and vendor lengths
-		engineNameMaxLen = max(engineNameMaxLen, len(engine.Name))
-		engineVendorMaxLen = max(engineVendorMaxLen, len(engine.Vendor))
+		engineNameMaxLen = max(engineNameMaxLen, len(engine.Name), len(headerRow[0]))
+		engineVendorMaxLen = max(engineVendorMaxLen, len(engine.Vendor), len(headerRow[1]))
 
 		row := []string{engine.Name, engine.Vendor, engine.Description}
 


### PR DESCRIPTION
Engine and Vendor columns are fixed to a minimum width of 6 chars to preserve titles when the longest of the entries is shorter than 6 chars

```
ENGINE                 VENDOR             DESCRIPTION                    COMPAT
cpu-avx512             Canonical Ltd      CPUs with AVX512               yes   
example-memory         Canonical Ltd      Legacy CPUs, offering full a…  yes   
cpu-avx2               Canonical Ltd      CPUs with AVX2                 yes   
cpu-avx1               Canonical Ltd      Legacy CPUs with only SSE4.2…  yes   
cpu                    Canonical Ltd      General CPU engine             yes   
cpu-devel              Canonical Ltd      Requires any CPU but is grad…  devel 
rocm-generic           Canonical Ltd      AMD GPUs using ROCm. All maj…  no    
not-compatible-engine  Canonical Ltd      This test engine is designed…  no    
intel-npu              Intel Corporation  Intel NPUs                     no    
intel-gpu              Intel Corporation  Modern Intel GPUs (>=gen 13)   no    
intel-cpu              Intel Corporation  Use Intel CPUs                 no    
ampere                 Canonical Ltd      Test ampere selection          no    
cuda-generic           Canonical Ltd      Nvidia GPUs using CUDA. All …  no    
amd-gpu                Canonical Ltd      AMD specific engine targetin…  no    
ampere-altra           Canonical Ltd      Test ampere selection          no    
arm-neon               Canonical Ltd      ARM CPUs with NEON instructi…  no 
```