### PR TITLE
Add basic riscv64 architecture support

### DIFF
--- a/pkg/engines/cpu.go
+++ b/pkg/engines/cpu.go
@@ -18,6 +18,8 @@ func (device Device) validateCpu() error {
 		return device.validateAmd64()
 	case constants.Arm64:
 		return device.validateArm64()
+	case constants.Riscv64:
+		return device.validateRiscv64()
 	default:
 		return fmt.Errorf("invalid architecture: %v", *device.Architecture)
 	}
@@ -67,6 +69,30 @@ func (device Device) validateArm64() error {
 		if fieldValue.IsValid() && !fieldValue.IsZero() {
 			if !slices.Contains(validFields, fieldName) {
 				return fmt.Errorf("arm64: invalid field: %s", fieldName)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (device Device) validateRiscv64() error {
+	validFields := []string{
+		"Type",
+		"Architecture",
+		"Isa",
+	}
+
+	t := reflect.TypeOf(device)
+	v := reflect.ValueOf(device)
+
+	// Check fields with values against allow list
+	for i := 0; i < t.NumField(); i++ {
+		fieldName := t.Field(i).Name
+		fieldValue := v.FieldByName(fieldName)
+		if fieldValue.IsValid() && !fieldValue.IsZero() {
+			if !slices.Contains(validFields, fieldName) {
+				return fmt.Errorf("riscv64: invalid field: %s", fieldName)
 			}
 		}
 	}

--- a/pkg/hardware_info/cpu/cpu.go
+++ b/pkg/hardware_info/cpu/cpu.go
@@ -76,6 +76,9 @@ func cpuInfoFromProc(procCpus []ProcCpuInfo) ([]types.CpuInfo, error) {
 			cpuInfo.ImplementerId = types.HexInt(procCpu.ImplementerId)
 			cpuInfo.PartNumber = types.HexInt(procCpu.PartNumber)
 			cpuInfo.Features = procCpu.Features
+		} else if procCpu.Architecture == constants.Riscv64 {
+			cpuInfo.Architecture = procCpu.Architecture
+			cpuInfo.Isa = procCpu.Isa
 		} else {
 			return nil, fmt.Errorf("unsupported architecture: %s", procCpu.Architecture)
 		}

--- a/pkg/hardware_info/cpu/proc_cpuinfo.go
+++ b/pkg/hardware_info/cpu/proc_cpuinfo.go
@@ -34,6 +34,13 @@ func parseProcCpuInfo(cpuInfoString string, architecture string) ([]ProcCpuInfo,
 			return nil, fmt.Errorf("arm64: %v", err)
 		}
 		return cpuInfo, nil
+	
+	case constants.Riscv64:
+		cpuInfo, err := parseProcCpuInfoRiscv64(cpuInfoString)
+		if err != nil {
+			return nil, fmt.Errorf("riscv64: %v", err)
+		}
+		return cpuInfo, nil
 
 	default:
 		return nil, fmt.Errorf("unsupported architecture: %s", architecture)
@@ -177,6 +184,55 @@ func parseProcCpuInfoArm64(cpuInfoString string) ([]ProcCpuInfo, error) {
 				return nil, err
 			}
 			parsedCpus[cpuIndex].Revision = revision
+		}
+	}
+
+	return parsedCpus, nil
+}
+
+func parseProcCpuInfoRiscv64(cpuInfoString string) ([]ProcCpuInfo, error) {
+	var parsedCpus []ProcCpuInfo
+
+	lines := strings.Split(cpuInfoString, "\n")
+	cpuIndex := 0
+
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		fields := strings.SplitN(line, ":", 2)
+		key := strings.TrimSpace(fields[0]) // remove \t between key and colon
+		value := strings.TrimSpace(fields[1])
+
+		// New cpu block
+		if key == "processor" {
+			newCpu := ProcCpuInfo{}
+			newCpu.Architecture = constants.Riscv64
+			parsedCpus = append(parsedCpus, newCpu)
+			cpuIndex = len(parsedCpus) - 1
+		}
+
+		switch key {
+
+		// "processor\t: %d\n"
+		case "processor":
+			processorIndex, err := strconv.ParseInt(value, 10, 64)
+			if err != nil {
+				return nil, err
+			}
+			parsedCpus[cpuIndex].Processor = processorIndex
+
+		// "model name\t: %s\n"
+		case "model name":
+			modelName := strings.TrimSpace(value)
+			parsedCpus[cpuIndex].ModelName = &modelName
+
+		// "isa\t:"+" %s"
+		case "isa":
+			flags := strings.Split(value, "_")
+			parsedCpus[cpuIndex].Isa = append(parsedCpus[cpuIndex].Isa, flags...)
+
 		}
 	}
 

--- a/pkg/hardware_info/cpu/proc_cpuinfo_test.go
+++ b/pkg/hardware_info/cpu/proc_cpuinfo_test.go
@@ -17,7 +17,7 @@ var procCpuInfoTestFiles = map[string]string{
 	"../../../test_data/machines/i7-2600k+arc-a580/cpuinfo.txt":                 constants.Amd64,
 	"../../../test_data/machines/i7-10510U/cpuinfo.txt":                         constants.Amd64,
 	"../../../test_data/machines/mustang/cpuinfo.txt":                           constants.Amd64,
-	//"../../../test_data/machines/orange-pi-rv2/cpuinfo.txt":                     constants.Riscv64,
+	"../../../test_data/machines/orange-pi-rv2/cpuinfo.txt":                     constants.Riscv64,
 	"../../../test_data/machines/raspberry-pi-5/cpuinfo.txt":         constants.Arm64,
 	"../../../test_data/machines/raspberry-pi-5+hailo-8/cpuinfo.txt": constants.Arm64,
 	"../../../test_data/machines/xps13-7390/cpuinfo.txt":             constants.Amd64,

--- a/pkg/hardware_info/cpu/types.go
+++ b/pkg/hardware_info/cpu/types.go
@@ -19,4 +19,7 @@ type ProcCpuInfo struct {
 	Variant    uint64 // 0x%x
 	PartNumber uint64 // 0x%03x
 	Revision   uint64 // %d
+
+	// riscv64
+	Isa           []string // extensions
 }

--- a/pkg/types/cpu.go
+++ b/pkg/types/cpu.go
@@ -11,4 +11,7 @@ type CpuInfo struct {
 	ImplementerId HexInt   `json:"implementer-id,omitempty" yaml:"implementer-id,omitempty"`
 	PartNumber    HexInt   `json:"part-number,omitempty" yaml:"part-number,omitempty"`
 	Features      []string `json:"features,omitempty" yaml:"features,omitempty"`
+
+	// riscv64
+	Isa           []string `json:"isa,omitempty" yaml:"isa,omitempty"`
 }

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,14 +52,23 @@ parts:
   nvidia-smi:
     plugin: nil
     build-packages:
-      - nvidia-utils-580
+      - to amd64:
+        - nvidia-utils-580
+      - to arm64:
+        - nvidia-utils-580
     override-build: |
       mkdir -p $CRAFT_PART_INSTALL/usr/bin
-      cp /usr/bin/nvidia-smi $CRAFT_PART_INSTALL/usr/bin/
       
-      license_dir=$CRAFT_PART_INSTALL/usr/share/doc/nvidia-utils-580/
-      mkdir -p $license_dir
-      cp /usr/share/doc/nvidia-utils-580/copyright $license_dir/
+      if [ "$CRAFT_ARCH_BUILD_FOR" == "amd64" ] || [ "$CRAFT_ARCH_BUILD_FOR" == "arm64" ]; then
+        cp /usr/bin/nvidia-smi $CRAFT_PART_INSTALL/usr/bin/
+        
+        license_dir=$CRAFT_PART_INSTALL/usr/share/doc/nvidia-utils-580/
+        mkdir -p $license_dir
+        cp /usr/share/doc/nvidia-utils-580/copyright $license_dir/
+      else
+        echo -e "#!/bin/sh\necho nvidia drivers are not available on $CRAFT_ARCH_BUILD_FOR\nexit 1" > $CRAFT_PART_INSTALL/usr/bin/nvidia-smi
+        chmod a+rx $CRAFT_PART_INSTALL/usr/bin/nvidia-smi
+      fi
 
   # OpenCL ICD and libigdgmm are required for Intel GPU vRAM lookup with clinfo
   intel-opencl-icd:

--- a/test_data/engines/cpu/engine.yaml
+++ b/test_data/engines/cpu/engine.yaml
@@ -8,6 +8,8 @@ devices:
       architecture: amd64
     - type: cpu
       architecture: arm64
+    - type: cpu
+      architecture: riscv64
 memory: 4G
 disk-space: 8G
 


### PR DESCRIPTION
This adds basic riscv64 architecture support.
It allows building the snap on riscv64, and then running basic commands:
```
ubuntu@p550:~$ inference-snaps-cli show-machine
cpus:
    - architecture: riscv64
      isa:
        - rv64imafdch
        - zicsr
        - zifencei
        - zba
        - zbb
        - sscofpmf
memory:
    total-ram: 16743100416
    total-swap: 0
disk:
    /var/lib/snapd/snaps:
        total: 125930070016
        avail: 14767624192
pci:
    - slot: "0000:00:00.0"
      bus-number: "0x0"
      device-class: "0x604"
      programming-interface: 0
      vendor-id: "0x1FE1"
      device-id: "0x2030"
      vendor-name: Beijing ESWIN Computing Technology Co., Ltd.
      device-name: EIC7700 Root Complex
```

The CPU detection shows available RISC-V ISA extensions, allowing for future riscv64 vector/matrix engine detection.

We can also run the engine selection code on test data:
```
ubuntu@p550:~$ inference-snaps-cli show-machine --format=json | inference-snaps-cli debug select-engine --engines test_data/engines/
❌ amd-gpu - not compatible: required device not found
❌ ampere - not compatible: required device not found
❌ ampere-altra - not compatible: required device not found
❌ arm-neon - not compatible: required device not found
✅ cpu - compatible, score = 12
❌ cpu-avx1 - not compatible: required device not found
❌ cpu-avx2 - not compatible: required device not found
❌ cpu-avx512 - not compatible: required device not found
❌ cpu-exptl - not compatible: required device not found
❌ cuda-generic - not compatible: required device not found
❌ example-memory - not compatible: insufficient memory, insufficient disk space, required device not found
❌ intel-cpu - not compatible: required device not found
❌ intel-gpu - not compatible: required device not found
❌ intel-npu - not compatible: required device not found
❌ not-compatible-engine - not compatible: required device not found
❌ rocm-generic - not compatible: required device not found
Selected engine for your hardware configuration: cpu

engines:
    - name: amd-gpu
      description: AMD specific engine targeting only one microarchitecture.
      vendor: Canonical Ltd
...
```