### PR TITLE
Add deprecation notice to hardware_info package

### DIFF
--- a/pkg/hardware_info/README.md
+++ b/pkg/hardware_info/README.md
@@ -1,0 +1,4 @@
+# Hardware info
+
+> [!CAUTION]
+> This package has been deprecated in favor of https://github.com/canonical/lscompute/tree/main/pkg/machine


### PR DESCRIPTION
This package has been deprecated in favor of the lscompute package: https://github.com/canonical/lscompute/tree/main/pkg/machine