### PR TITLE
Rename CLI module to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,13 @@
-module github.com/canonical/inference-snaps-cli
+module github.com/canonical/inference-snaps-cli/v2
+
+replace github.com/canonical/inference-snaps-cli => ./
 
 go 1.26.1
 
 require (
 	github.com/briandowns/spinner v1.23.2
 	github.com/canonical/go-snapctl v1.0.0-beta.6
+	github.com/canonical/inference-snaps-cli v0.0.0-00010101000000-000000000000
 	github.com/chzyer/readline v1.5.1
 	github.com/creack/pty v1.1.24
 	github.com/fatih/color v1.19.0


### PR DESCRIPTION
This PR adds `/v2` to the module name, to match the newest major release, and introduces a **replace** directive to point every cli import to the project directory

This way, go can also pick up the latest `v2.*` tag and read the correct version information:

Before the PR:

```shell
$ ./cli version
snap: unset
cli: v1.0.1-0.20260609124438-3b6ae859577a
```

After the PR:

```shell
$ ./cli version
snap: unset
cli: v2.0.0-beta.0.20260610161711-e70838c23f55
```