### PR TITLE
Installing snap with components overrides engine selection

### DIFF
--- a/cmd/modelctl/commands/show-engine_test.go
+++ b/cmd/modelctl/commands/show-engine_test.go
@@ -114,7 +114,14 @@ func Example_showEngineCommand_printEngineManifestYaml() {
 	//           vram: 5G
 	//           compatibility-issues:
 	//             - device not found
-	// configurations: {}
+	// runtime: llama-cpp-cuda
+	// model:
+	//     default: 26b-q4-k-m-gguf
+	//     options:
+	//         - 26b-q4-k-m-gguf
+	//         - 30b-a3b-q4-k-m-gguf
+	// configurations:
+	//     sleep-idle-seconds: 600
 	// score: 0
 	// compatible: false
 	// compatibility-issues:
@@ -170,12 +177,17 @@ func Example_showEngineCommand_printEngineManifestJson() {
 	//       }
 	//     ]
 	//   },
-	//   "runtime": "",
+	//   "runtime": "llama-cpp-cuda",
 	//   "model": {
-	//     "default": "",
-	//     "options": null
+	//     "default": "26b-q4-k-m-gguf",
+	//     "options": [
+	//       "26b-q4-k-m-gguf",
+	//       "30b-a3b-q4-k-m-gguf"
+	//     ]
 	//   },
-	//   "configurations": null,
+	//   "configurations": {
+	//     "sleep-idle-seconds": 600
+	//   },
 	//   "score": 0,
 	//   "compatible": false,
 	//   "compatibility-issues": [

--- a/cmd/modelctl/commands/use-engine.go
+++ b/cmd/modelctl/commands/use-engine.go
@@ -339,7 +339,18 @@ func (cmd *useEngineCommand) migrateConfig() error {
 	return nil
 }
 
+// engineNames extracts the Name field from a slice of engine manifests using the provided accessor.
+func engineNames[T any](items []T, getName func(T) string) []string {
+	names := make([]string, len(items))
+	for i, item := range items {
+		names[i] = getName(item)
+	}
+	return names
+}
+
 func switchToPreinstalledEngineAndModel(cmd *useEngineCommand, scoredEngines []engines.ScoredManifest) (bool, error) {
+	fmt.Println("Checking preinstalled components to influence engine and model selection")
+
 	allEngines, err := engines.LoadManifests(cmd.EnginesDir)
 	if err != nil {
 		return false, err
@@ -358,6 +369,8 @@ func switchToPreinstalledEngineAndModel(cmd *useEngineCommand, scoredEngines []e
 		return false, err
 	}
 
+	fmt.Printf("Installed components: %v\n", installedComponents)
+
 	var seededRuntimes []string
 	var seededModels []string
 
@@ -374,6 +387,7 @@ func switchToPreinstalledEngineAndModel(cmd *useEngineCommand, scoredEngines []e
 			seededRuntimes = append(seededRuntimes, runtime.ID)
 		}
 	}
+	fmt.Printf("Seeded runtimes: %v\n", seededRuntimes)
 
 	for _, model := range allModels {
 		// check if all the model.Components are included in installedComponents. If it is, add the model ID to seededModels
@@ -388,6 +402,7 @@ func switchToPreinstalledEngineAndModel(cmd *useEngineCommand, scoredEngines []e
 			seededModels = append(seededModels, model.ID)
 		}
 	}
+	fmt.Printf("Seeded models: %v\n", seededModels)
 
 	// iterate all engines and make a list of ones for which the runtime is in seededRuntimes, or at least one of its model options is in seededModels.
 	// Engines where both conditions are true are preferred over engines where only one condition is true.
@@ -408,6 +423,8 @@ func switchToPreinstalledEngineAndModel(cmd *useEngineCommand, scoredEngines []e
 			partiallySeededEngines = append(partiallySeededEngines, engine)
 		}
 	}
+	fmt.Printf("Partially seeded engines: %v\n", engineNames(partiallySeededEngines, func(e engines.Manifest) string { return e.Name }))
+	fmt.Printf("Fully seeded engines: %v\n", engineNames(fullySeededEngines, func(e engines.Manifest) string { return e.Name }))
 
 	// filterCompatible returns the subset of the given engines that have a score >0 in scoredEngines.
 	filterCompatible := func(candidates []engines.Manifest) []engines.ScoredManifest {
@@ -428,9 +445,11 @@ func switchToPreinstalledEngineAndModel(cmd *useEngineCommand, scoredEngines []e
 	if len(compatibleSeededEngines) == 0 {
 		compatibleSeededEngines = filterCompatible(partiallySeededEngines)
 	}
+	fmt.Printf("Compatible seeded engines: %v\n", engineNames(compatibleSeededEngines, func(e engines.ScoredManifest) string { return e.Name }))
 
 	// Seeded components do not target any compatible engine
 	if len(compatibleSeededEngines) == 0 {
+		fmt.Printf("No compatible seeded engines found; falling back to standard auto selection.\n")
 		return false, nil
 	}
 
@@ -439,6 +458,7 @@ func switchToPreinstalledEngineAndModel(cmd *useEngineCommand, scoredEngines []e
 	if err != nil {
 		return false, fmt.Errorf("finding top engine: %v", err)
 	}
+	fmt.Printf("Top engine: %v\n", topEngine.Name)
 
 	// at this point we need to also know which one of the seeded models is the one from model.options of the topEngine
 	// If there are multiple matches, prefer the default model
@@ -451,10 +471,14 @@ func switchToPreinstalledEngineAndModel(cmd *useEngineCommand, scoredEngines []e
 			}
 		}
 	}
-
-	err = cmd.Cache.SetActiveModel(seededModelForEngine)
-	if err != nil {
-		return false, fmt.Errorf("setting active model: %v", err)
+	fmt.Printf("Seeded model for engine: %v\n", seededModelForEngine)
+	// If one of the components defined a supported model, set it as the active model.
+	// Otherwise leave the active model unset so that the default can be set by switchEngine()
+	if seededModelForEngine != "" {
+		err = cmd.Cache.SetActiveModel(seededModelForEngine)
+		if err != nil {
+			return false, fmt.Errorf("setting active model: %v", err)
+		}
 	}
 
 	err = cmd.switchEngine(topEngine.Name)

--- a/cmd/modelctl/commands/use-engine.go
+++ b/cmd/modelctl/commands/use-engine.go
@@ -375,16 +375,12 @@ func switchToPreinstalledEngineAndModel(cmd *useEngineCommand, scoredEngines []e
 	var seededModels []string
 
 	for _, runtime := range allRuntimes {
-		// check if all the runtime.Components are included in installedComponents. If it is, add the runtime name to seededRuntimes
-		allInstalled := true
+		// check if at least one of the runtime.Components is included in installedComponents. If it is, add the runtime name to seededRuntimes
 		for _, component := range runtime.Components {
-			if !slices.Contains(installedComponents, component) {
-				allInstalled = false
+			if slices.Contains(installedComponents, component) {
+				seededRuntimes = append(seededRuntimes, runtime.ID)
 				break
 			}
-		}
-		if allInstalled {
-			seededRuntimes = append(seededRuntimes, runtime.ID)
 		}
 	}
 	fmt.Printf("Seeded runtimes: %v\n", seededRuntimes)

--- a/cmd/modelctl/commands/use-engine.go
+++ b/cmd/modelctl/commands/use-engine.go
@@ -8,6 +8,7 @@ import (
 	"github.com/canonical/inference-snaps-cli/v2/cmd/modelctl/common"
 	"github.com/canonical/inference-snaps-cli/v2/pkg/engines"
 	"github.com/canonical/inference-snaps-cli/v2/pkg/models"
+	"github.com/canonical/inference-snaps-cli/v2/pkg/runtimes"
 	"github.com/canonical/inference-snaps-cli/v2/pkg/selector"
 	"github.com/canonical/inference-snaps-cli/v2/pkg/utils"
 	"github.com/spf13/cobra"
@@ -17,11 +18,12 @@ type useEngineCommand struct {
 	*common.Context
 
 	// flags
-	auto      bool
-	fix       bool
-	fallback  string
-	assumeYes bool
-	noRestart bool
+	auto               bool
+	fix                bool
+	fallback           string
+	assumeYes          bool
+	noRestart          bool
+	considerComponents bool
 }
 
 func UseEngine(ctx *common.Context) *cobra.Command {
@@ -45,6 +47,7 @@ func UseEngine(ctx *common.Context) *cobra.Command {
 	cobraCmd.Flags().StringVar(&cmd.fallback, "fallback", "", "fallback engine to use when hardware information is unavailable (requires --auto or --fix)")
 	cobraCmd.Flags().BoolVar(&cmd.assumeYes, "assume-yes", false, "assume yes for all prompts")
 	cobraCmd.Flags().BoolVar(&cmd.noRestart, "no-restart", false, "do not restart the snap after changing engine")
+	cobraCmd.Flags().BoolVar(&cmd.considerComponents, "components", false, "consider pre-installed components")
 
 	return cobraCmd
 }
@@ -139,6 +142,20 @@ func (cmd *useEngineCommand) autoSelectScoredEngine(scoredEngines []engines.Scor
 		} else {
 			fmt.Printf("✔ %s: compatible, score=%d\n", engine.Name, engine.Score)
 		}
+	}
+
+	if cmd.considerComponents {
+		// Look at components that are currently installed
+		// Try and match this to an engine and model that are compatible
+		switched, err := switchToPreinstalledEngineAndModel(cmd, scoredEngines)
+		if err != nil {
+			return err
+		}
+		if switched {
+			// switched, so return success
+			return nil
+		}
+		// otherwise continue with standard auto selection
 	}
 
 	selectedEngine, err := selector.TopEngine(scoredEngines)
@@ -320,4 +337,130 @@ func (cmd *useEngineCommand) migrateConfig() error {
 		return fmt.Errorf("migrating config: %v", err)
 	}
 	return nil
+}
+
+func switchToPreinstalledEngineAndModel(cmd *useEngineCommand, scoredEngines []engines.ScoredManifest) (bool, error) {
+	allEngines, err := engines.LoadManifests(cmd.EnginesDir)
+	if err != nil {
+		return false, err
+	}
+	allRuntimes, err := runtimes.LoadManifests(cmd.RuntimesDir)
+	if err != nil {
+		return false, err
+	}
+	allModels, err := models.LoadManifests(cmd.ModelsDir)
+	if err != nil {
+		return false, err
+	}
+
+	installedComponents, err := common.InstalledComponents()
+	if err != nil {
+		return false, err
+	}
+
+	var seededRuntimes []string
+	var seededModels []string
+
+	for _, runtime := range allRuntimes {
+		// check if all the runtime.Components are included in installedComponents. If it is, add the runtime name to seededRuntimes
+		allInstalled := true
+		for _, component := range runtime.Components {
+			if !slices.Contains(installedComponents, component) {
+				allInstalled = false
+				break
+			}
+		}
+		if allInstalled {
+			seededRuntimes = append(seededRuntimes, runtime.ID)
+		}
+	}
+
+	for _, model := range allModels {
+		// check if all the model.Components are included in installedComponents. If it is, add the model ID to seededModels
+		allInstalled := true
+		for _, component := range model.Components {
+			if !slices.Contains(installedComponents, component) {
+				allInstalled = false
+				break
+			}
+		}
+		if allInstalled {
+			seededModels = append(seededModels, model.ID)
+		}
+	}
+
+	// iterate all engines and make a list of ones for which the runtime is in seededRuntimes, or at least one of its model options is in seededModels.
+	// Engines where both conditions are true are preferred over engines where only one condition is true.
+	var fullySeededEngines []engines.Manifest
+	var partiallySeededEngines []engines.Manifest
+	for _, engine := range allEngines {
+		hasSeededRuntime := slices.Contains(seededRuntimes, engine.Runtime)
+		hasSeededModel := false
+		for _, option := range engine.Model.Options {
+			if slices.Contains(seededModels, option) {
+				hasSeededModel = true
+				break
+			}
+		}
+		if hasSeededRuntime && hasSeededModel {
+			fullySeededEngines = append(fullySeededEngines, engine)
+		} else if hasSeededRuntime || hasSeededModel {
+			partiallySeededEngines = append(partiallySeededEngines, engine)
+		}
+	}
+
+	// filterCompatible returns the subset of the given engines that have a score >0 in scoredEngines.
+	filterCompatible := func(candidates []engines.Manifest) []engines.ScoredManifest {
+		var compatible []engines.ScoredManifest
+		for _, candidate := range candidates {
+			for _, scoredEngine := range scoredEngines {
+				if scoredEngine.Name == candidate.Name && scoredEngine.Score > 0 {
+					compatible = append(compatible, scoredEngine)
+					break
+				}
+			}
+		}
+		return compatible
+	}
+
+	// Prefer engines with both a seeded runtime and a seeded model; fall back to partially seeded engines.
+	compatibleSeededEngines := filterCompatible(fullySeededEngines)
+	if len(compatibleSeededEngines) == 0 {
+		compatibleSeededEngines = filterCompatible(partiallySeededEngines)
+	}
+
+	// Seeded components do not target any compatible engine
+	if len(compatibleSeededEngines) == 0 {
+		return false, nil
+	}
+
+	// If multiple seeded engines, find the top one
+	topEngine, err := selector.TopEngine(compatibleSeededEngines)
+	if err != nil {
+		return false, fmt.Errorf("finding top engine: %v", err)
+	}
+
+	// at this point we need to also know which one of the seeded models is the one from model.options of the topEngine
+	// If there are multiple matches, prefer the default model
+	seededModelForEngine := ""
+	for _, option := range topEngine.Model.Options {
+		if slices.Contains(seededModels, option) {
+			seededModelForEngine = option
+			if option == topEngine.Model.Default {
+				break
+			}
+		}
+	}
+
+	err = cmd.Cache.SetActiveModel(seededModelForEngine)
+	if err != nil {
+		return false, fmt.Errorf("setting active model: %v", err)
+	}
+
+	err = cmd.switchEngine(topEngine.Name)
+	if err != nil {
+		return false, fmt.Errorf("switching engine: %v", err)
+	}
+
+	return true, nil
 }

--- a/cmd/modelctl/commands/use-engine.go
+++ b/cmd/modelctl/commands/use-engine.go
@@ -390,16 +390,12 @@ func switchToPreinstalledEngineAndModel(cmd *useEngineCommand, scoredEngines []e
 	fmt.Printf("Seeded runtimes: %v\n", seededRuntimes)
 
 	for _, model := range allModels {
-		// check if all the model.Components are included in installedComponents. If it is, add the model ID to seededModels
-		allInstalled := true
+		// check if at least one of the model.Components is included in installedComponents. If it is, add the model ID to seededModels
 		for _, component := range model.Components {
-			if !slices.Contains(installedComponents, component) {
-				allInstalled = false
+			if slices.Contains(installedComponents, component) {
+				seededModels = append(seededModels, model.ID)
 				break
 			}
-		}
-		if allInstalled {
-			seededModels = append(seededModels, model.ID)
 		}
 	}
 	fmt.Printf("Seeded models: %v\n", seededModels)

--- a/cmd/modelctl/commands/use-engine.go
+++ b/cmd/modelctl/commands/use-engine.go
@@ -374,8 +374,9 @@ func switchToPreinstalledEngineAndModel(cmd *useEngineCommand, scoredEngines []e
 	var seededRuntimes []string
 	var seededModels []string
 
+	// A runtime or model is considered seeded if any one required component for the respective runtime or model is currently installed.
+
 	for _, runtime := range allRuntimes {
-		// check if at least one of the runtime.Components is included in installedComponents. If it is, add the runtime name to seededRuntimes
 		for _, component := range runtime.Components {
 			if slices.Contains(installedComponents, component) {
 				seededRuntimes = append(seededRuntimes, runtime.ID)
@@ -386,7 +387,6 @@ func switchToPreinstalledEngineAndModel(cmd *useEngineCommand, scoredEngines []e
 	fmt.Printf("Seeded runtimes: %v\n", seededRuntimes)
 
 	for _, model := range allModels {
-		// check if at least one of the model.Components is included in installedComponents. If it is, add the model ID to seededModels
 		for _, component := range model.Components {
 			if slices.Contains(installedComponents, component) {
 				seededModels = append(seededModels, model.ID)

--- a/cmd/modelctl/commands/use-engine.go
+++ b/cmd/modelctl/commands/use-engine.go
@@ -47,7 +47,7 @@ func UseEngine(ctx *common.Context) *cobra.Command {
 	cobraCmd.Flags().StringVar(&cmd.fallback, "fallback", "", "fallback engine to use when hardware information is unavailable (requires --auto or --fix)")
 	cobraCmd.Flags().BoolVar(&cmd.assumeYes, "assume-yes", false, "assume yes for all prompts")
 	cobraCmd.Flags().BoolVar(&cmd.noRestart, "no-restart", false, "do not restart the snap after changing engine")
-	cobraCmd.Flags().BoolVar(&cmd.considerComponents, "components", false, "consider pre-installed components")
+	cobraCmd.Flags().BoolVar(&cmd.considerComponents, "components", false, "consider pre-installed components (requires --auto)")
 
 	return cobraCmd
 }
@@ -74,6 +74,10 @@ func (cmd *useEngineCommand) run(_ *cobra.Command, args []string) error {
 
 	if cmd.fallback != "" && !cmd.auto && !cmd.fix {
 		return fmt.Errorf("--fallback must be used together with --auto or --fix")
+	}
+
+	if cmd.considerComponents && !cmd.auto {
+		return fmt.Errorf("--components must be used together with --auto")
 	}
 
 	if cmd.auto {
@@ -145,14 +149,11 @@ func (cmd *useEngineCommand) autoSelectScoredEngine(scoredEngines []engines.Scor
 	}
 
 	if cmd.considerComponents {
-		// Look at components that are currently installed
-		// Try and match this to an engine and model that are compatible
-		switched, err := switchToPreinstalledEngineAndModel(cmd, scoredEngines)
+		ok, err := selectEngineForSeededComponents(cmd, scoredEngines)
 		if err != nil {
 			return err
 		}
-		if switched {
-			// switched, so return success
+		if ok {
 			return nil
 		}
 		// otherwise continue with standard auto selection
@@ -348,7 +349,9 @@ func engineNames[T any](items []T, getName func(T) string) []string {
 	return names
 }
 
-func switchToPreinstalledEngineAndModel(cmd *useEngineCommand, scoredEngines []engines.ScoredManifest) (bool, error) {
+// selectEngineForSeededComponents looks at components that are currently installed,
+// tries to match these to an engine and model that are compatible, and switches to it.
+func selectEngineForSeededComponents(cmd *useEngineCommand, scoredEngines []engines.ScoredManifest) (bool, error) {
 	fmt.Println("Checking preinstalled components to influence engine and model selection")
 
 	allEngines, err := engines.LoadManifests(cmd.EnginesDir)
@@ -374,12 +377,12 @@ func switchToPreinstalledEngineAndModel(cmd *useEngineCommand, scoredEngines []e
 	var seededRuntimes []string
 	var seededModels []string
 
-	// A runtime or model is considered seeded if any one required component for the respective runtime or model is currently installed.
+	// A runtime or model is considered seeded if any of its components are currently installed
 
 	for _, runtime := range allRuntimes {
 		for _, component := range runtime.Components {
 			if slices.Contains(installedComponents, component) {
-				seededRuntimes = append(seededRuntimes, runtime.ID)
+				seededRuntimes = append(seededRuntimes, runtime.Name)
 				break
 			}
 		}
@@ -396,8 +399,7 @@ func switchToPreinstalledEngineAndModel(cmd *useEngineCommand, scoredEngines []e
 	}
 	fmt.Printf("Seeded models: %v\n", seededModels)
 
-	// iterate all engines and make a list of ones for which the runtime is in seededRuntimes, or at least one of its model options is in seededModels.
-	// Engines where both conditions are true are preferred over engines where only one condition is true.
+	// Check which engines have a seeded runtime and/or a seeded model
 	var fullySeededEngines []engines.Manifest
 	var partiallySeededEngines []engines.Manifest
 	for _, engine := range allEngines {
@@ -415,10 +417,24 @@ func switchToPreinstalledEngineAndModel(cmd *useEngineCommand, scoredEngines []e
 			partiallySeededEngines = append(partiallySeededEngines, engine)
 		}
 	}
-	fmt.Printf("Partially seeded engines: %v\n", engineNames(partiallySeededEngines, func(e engines.Manifest) string { return e.Name }))
-	fmt.Printf("Fully seeded engines: %v\n", engineNames(fullySeededEngines, func(e engines.Manifest) string { return e.Name }))
 
-	// filterCompatible returns the subset of the given engines that have a score >0 in scoredEngines.
+	fmt.Printf("Partially seeded engines: %v\n",
+		engineNames(partiallySeededEngines,
+			func(e engines.Manifest) string {
+				return e.Name
+			},
+		),
+	)
+
+	fmt.Printf("Fully seeded engines: %v\n",
+		engineNames(fullySeededEngines,
+			func(e engines.Manifest) string {
+				return e.Name
+			},
+		),
+	)
+
+	// filterCompatible returns the subset of engines that are compatible
 	filterCompatible := func(candidates []engines.Manifest) []engines.ScoredManifest {
 		var compatible []engines.ScoredManifest
 		for _, candidate := range candidates {
@@ -432,7 +448,7 @@ func switchToPreinstalledEngineAndModel(cmd *useEngineCommand, scoredEngines []e
 		return compatible
 	}
 
-	// Prefer engines with both a seeded runtime and a seeded model; fall back to partially seeded engines.
+	// Prefer engines with both a seeded runtime and a seeded model
 	compatibleSeededEngines := filterCompatible(fullySeededEngines)
 	if len(compatibleSeededEngines) == 0 {
 		compatibleSeededEngines = filterCompatible(partiallySeededEngines)
@@ -452,8 +468,7 @@ func switchToPreinstalledEngineAndModel(cmd *useEngineCommand, scoredEngines []e
 	}
 	fmt.Printf("Top engine: %v\n", topEngine.Name)
 
-	// at this point we need to also know which one of the seeded models is the one from model.options of the topEngine
-	// If there are multiple matches, prefer the default model
+	// If multiple models were seeded, prefer the engine's default
 	seededModelForEngine := ""
 	for _, option := range topEngine.Model.Options {
 		if slices.Contains(seededModels, option) {
@@ -463,8 +478,8 @@ func switchToPreinstalledEngineAndModel(cmd *useEngineCommand, scoredEngines []e
 			}
 		}
 	}
-	// If one of the components defined a supported model, set it as the active model.
-	// Otherwise leave the active model unset so that the default can be set by switchEngine()
+
+	// If a model was seeded, switch to it. Otherwise, switchEngine() will use the default model.
 	if seededModelForEngine != "" {
 		fmt.Printf("Seeded model for engine: %v\n", seededModelForEngine)
 		err = cmd.Cache.SetActiveModel(seededModelForEngine)

--- a/cmd/modelctl/commands/use-engine.go
+++ b/cmd/modelctl/commands/use-engine.go
@@ -471,10 +471,10 @@ func switchToPreinstalledEngineAndModel(cmd *useEngineCommand, scoredEngines []e
 			}
 		}
 	}
-	fmt.Printf("Seeded model for engine: %v\n", seededModelForEngine)
 	// If one of the components defined a supported model, set it as the active model.
 	// Otherwise leave the active model unset so that the default can be set by switchEngine()
 	if seededModelForEngine != "" {
+		fmt.Printf("Seeded model for engine: %v\n", seededModelForEngine)
 		err = cmd.Cache.SetActiveModel(seededModelForEngine)
 		if err != nil {
 			return false, fmt.Errorf("setting active model: %v", err)

--- a/cmd/modelctl/commands/use-engine_test.go
+++ b/cmd/modelctl/commands/use-engine_test.go
@@ -13,6 +13,53 @@ import (
 	"github.com/canonical/inference-snaps-cli/v2/pkg/storage"
 )
 
+// setupSnapComponents creates a temporary directory, populates it with a
+// subdirectory for each named component, sets SNAP_COMPONENTS to that
+// directory for the duration of the test, and registers a cleanup that
+// removes the directory.
+func setupSnapComponents(t *testing.T, components ...string) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "snap-components-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	for _, c := range components {
+		if err := os.Mkdir(dir+"/"+c, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("SNAP_COMPONENTS", dir)
+}
+
+// newUseEngineCmd builds a useEngineCommand backed by mock storage and a fresh
+// cache, wired to the shared test_data directories.
+func newUseEngineCmd() *useEngineCommand {
+	return &useEngineCommand{
+		assumeYes: true,
+		noRestart: true,
+		Context: &common.Context{
+			EnginesDir:  "../../../test_data/engines",
+			RuntimesDir: "../../../test_data/runtimes",
+			ModelsDir:   "../../../test_data/models",
+			Cache:       storage.NewMockCache(),
+			Config:      storage.NewMockConfig(),
+			Snap:        snap.Mock(),
+		},
+	}
+}
+
+// loadScoredEngine loads an engine manifest from test_data and wraps it in a
+// ScoredManifest with the given score (0 = incompatible).
+func loadScoredEngine(t *testing.T, name string, score int) engines.ScoredManifest {
+	t.Helper()
+	m, err := engines.LoadManifest("../../../test_data/engines", name)
+	if err != nil {
+		t.Fatalf("loading engine %q: %v", name, err)
+	}
+	return engines.ScoredManifest{Manifest: *m, Score: score}
+}
+
 func ExampleUseEngine_noRestartWhenEngineUnchanged() {
 	// intel-gpu now requires runtime and model components, so we need SNAP_COMPONENTS
 	// to be set with those component directories so InstallMissingComponents is a no-op.
@@ -215,3 +262,209 @@ func TestFixActiveEngine_fallbackWhenActiveEngineMissing(t *testing.T) {
 		t.Errorf("expected active engine to be 'amd-gpu', got %q", activeEngine)
 	}
 }
+
+// TestSwitchToPreinstalledEngineAndModel covers the component-aware engine
+// selection logic introduced in switchToPreinstalledEngineAndModel.
+//
+// Each sub-test mocks the scored-engine list (so no real hardware is needed)
+// and populates a temporary SNAP_COMPONENTS directory with the components that
+// should appear "installed".  After the call the test verifies which engine
+// and model landed in the cache.
+//
+// The scenarios mirror the manual tests performed on a laptop with an Intel
+// CPU + Intel GPU (where intel-gpu normally wins on score alone):
+//
+//	installed component               expected engine   expected model
+//	──────────────────────────────────────────────────────────────────
+//	model-26b-a4b-q4-k-m-gguf         cpu               26b-q4-k-m-gguf
+//	mmproj-26b-bf16-gguf               cpu               26b-q4-k-m-gguf
+//	model-4b-it-int4-fq-ov             intel-gpu         4b-it-int4-fq-ov
+//	runtime-llama-cpp-cpu              cpu               26b-q4-k-m-gguf (default)
+//	model-30b-a3b-q4-k-m-gguf-3-of-6  cpu               30b-a3b-q4-k-m-gguf
+//	runtime-llama-cpp-cuda (incompat.) –                 – (falls back, returns false)
+func TestSwitchToPreinstalledEngineAndModel(t *testing.T) {
+	// All required components for cpu + 26b-q4-k-m-gguf (runtime + model shards).
+	// Pre-installing them makes InstallMissingComponents a no-op so the test
+	// output stays clean.
+	cpuAnd26bComponents := []string{
+		"runtime-llama-cpp-cpu",
+		"model-26b-a4b-q4-k-m-gguf",
+		"mmproj-26b-bf16-gguf",
+	}
+	// All required components for cpu + 30b-a3b-q4-k-m-gguf.
+	cpuAnd30bComponents := []string{
+		"runtime-llama-cpp-cpu",
+		"model-30b-a3b-q4-k-m-gguf-1-of-6",
+		"model-30b-a3b-q4-k-m-gguf-2-of-6",
+		"model-30b-a3b-q4-k-m-gguf-3-of-6",
+		"model-30b-a3b-q4-k-m-gguf-4-of-6",
+		"model-30b-a3b-q4-k-m-gguf-5-of-6",
+		"model-30b-a3b-q4-k-m-gguf-6-of-6",
+	}
+	// All required components for intel-gpu + 4b-it-int4-fq-ov.
+	intelGpuAnd4bComponents := []string{
+		"runtime-openvino-model-server",
+		"model-4b-it-int4-fq-ov",
+	}
+
+	tests := []struct {
+		name                string
+		installedComponents []string
+		// engineScores lists the engines exposed to the function as already
+		// scored.  Use score=0 to mark an engine as hardware-incompatible.
+		engineScores []struct {
+			name  string
+			score int
+		}
+		wantSwitched bool
+		wantEngine   string
+		wantModel    string
+	}{
+		{
+			// A single GGUF model component is enough to seed the model, which
+			// in turn points to the cpu engine – even though intel-gpu has a
+			// higher hardware-compatibility score.
+			name:                "gguf model component selects cpu over higher-scored intel-gpu",
+			installedComponents: cpuAnd26bComponents,
+			engineScores: []struct {
+				name  string
+				score int
+			}{
+				{"cpu", 10},
+				{"intel-gpu", 20}, // higher score, but its model is not seeded
+			},
+			wantSwitched: true,
+			wantEngine:   "cpu",
+			wantModel:    "26b-q4-k-m-gguf",
+		},
+		{
+			// The mmproj component alone is sufficient to identify the 26b
+			// model and choose the cpu engine.  The missing model shard
+			// (model-26b-a4b-q4-k-m-gguf) would be installed by the mock snap
+			// when switchEngine runs InstallMissingComponents.
+			name: "mmproj component alone seeds cpu engine via 26b model",
+			installedComponents: []string{
+				"mmproj-26b-bf16-gguf",   // seed: one component of 26b-q4-k-m-gguf model
+				"runtime-llama-cpp-cpu",  // required by cpu runtime; avoids runtime-install noise
+			},
+			engineScores: []struct {
+				name  string
+				score int
+			}{
+				{"cpu", 10},
+				{"intel-gpu", 20},
+			},
+			wantSwitched: true,
+			wantEngine:   "cpu",
+			wantModel:    "26b-q4-k-m-gguf",
+		},
+		{
+			// An OpenVINO model component seeds the intel-gpu engine.
+			name:                "openvino model component selects intel-gpu",
+			installedComponents: intelGpuAnd4bComponents,
+			engineScores: []struct {
+				name  string
+				score int
+			}{
+				{"cpu", 10},
+				{"intel-gpu", 20},
+			},
+			wantSwitched: true,
+			wantEngine:   "intel-gpu",
+			wantModel:    "4b-it-int4-fq-ov",
+		},
+		{
+			// The cpu runtime component seeds the cpu engine.  Because no model
+			// component is installed the engine's default model is used.
+			name:                "cpu runtime component seeds cpu engine with default model",
+			installedComponents: cpuAnd26bComponents,
+			engineScores: []struct {
+				name  string
+				score int
+			}{
+				{"cpu", 10},
+				{"intel-gpu", 20},
+			},
+			wantSwitched: true,
+			wantEngine:   "cpu",
+			wantModel:    "26b-q4-k-m-gguf",
+		},
+		{
+			// A single shard of a multi-shard model is enough to seed the whole
+			// model (any one component match is sufficient).
+			name:                "single shard of multi-shard model seeds cpu engine with 30b model",
+			installedComponents: cpuAnd30bComponents, // shard 3 is the seed; all present for clean switchEngine
+			engineScores: []struct {
+				name  string
+				score int
+			}{
+				{"cpu", 10},
+				{"intel-gpu", 0}, // incompatible on this (hypothetical) machine
+			},
+			wantSwitched: true,
+			wantEngine:   "cpu",
+			wantModel:    "30b-a3b-q4-k-m-gguf",
+		},
+		{
+			// Installing a CUDA runtime component when the CUDA engine is
+			// hardware-incompatible (score=0) must not influence selection.
+			// The function should return false so the caller falls back to
+			// standard auto-selection.
+			name:                "incompatible cuda runtime component falls back to standard selection",
+			installedComponents: []string{"runtime-llama-cpp-cuda"},
+			engineScores: []struct {
+				name  string
+				score int
+			}{
+				{"cuda-generic", 0}, // seeded by installed component, but incompatible
+				{"cpu", 10},
+				{"intel-gpu", 20},
+			},
+			wantSwitched: false,
+			wantEngine:   "", // no engine set by this function
+			wantModel:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupSnapComponents(t, tt.installedComponents...)
+
+			var scored []engines.ScoredManifest
+			for _, es := range tt.engineScores {
+				scored = append(scored, loadScoredEngine(t, es.name, es.score))
+			}
+
+			cmd := newUseEngineCmd()
+			switched, err := switchToPreinstalledEngineAndModel(cmd, scored)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if switched != tt.wantSwitched {
+				t.Errorf("switched = %v, want %v", switched, tt.wantSwitched)
+			}
+
+			if tt.wantEngine != "" {
+				activeEngine, err := cmd.Cache.GetActiveEngine()
+				if err != nil {
+					t.Fatalf("getting active engine: %v", err)
+				}
+				if activeEngine != tt.wantEngine {
+					t.Errorf("active engine = %q, want %q", activeEngine, tt.wantEngine)
+				}
+			}
+
+			if tt.wantModel != "" {
+				activeModel, err := cmd.Cache.GetActiveModel()
+				if err != nil {
+					t.Fatalf("getting active model: %v", err)
+				}
+				if activeModel != tt.wantModel {
+					t.Errorf("active model = %q, want %q", activeModel, tt.wantModel)
+				}
+			}
+		})
+	}
+}
+

--- a/cmd/modelctl/commands/use-engine_test.go
+++ b/cmd/modelctl/commands/use-engine_test.go
@@ -265,23 +265,6 @@ func TestFixActiveEngine_fallbackWhenActiveEngineMissing(t *testing.T) {
 
 // TestSwitchToPreinstalledEngineAndModel covers the component-aware engine
 // selection logic introduced in switchToPreinstalledEngineAndModel.
-//
-// Each sub-test mocks the scored-engine list (so no real hardware is needed)
-// and populates a temporary SNAP_COMPONENTS directory with the components that
-// should appear "installed".  After the call the test verifies which engine
-// and model landed in the cache.
-//
-// The scenarios mirror the manual tests performed on a laptop with an Intel
-// CPU + Intel GPU (where intel-gpu normally wins on score alone):
-//
-//	installed component               expected engine   expected model
-//	──────────────────────────────────────────────────────────────────
-//	model-26b-a4b-q4-k-m-gguf         cpu               26b-q4-k-m-gguf
-//	mmproj-26b-bf16-gguf               cpu               26b-q4-k-m-gguf
-//	model-4b-it-int4-fq-ov             intel-gpu         4b-it-int4-fq-ov
-//	runtime-llama-cpp-cpu              cpu               26b-q4-k-m-gguf (default)
-//	model-30b-a3b-q4-k-m-gguf-3-of-6  cpu               30b-a3b-q4-k-m-gguf
-//	runtime-llama-cpp-cuda (incompat.) –                 – (falls back, returns false)
 func TestSwitchToPreinstalledEngineAndModel(t *testing.T) {
 	// All required components for cpu + 26b-q4-k-m-gguf (runtime + model shards).
 	// Pre-installing them makes InstallMissingComponents a no-op so the test
@@ -344,8 +327,8 @@ func TestSwitchToPreinstalledEngineAndModel(t *testing.T) {
 			// when switchEngine runs InstallMissingComponents.
 			name: "mmproj component alone seeds cpu engine via 26b model",
 			installedComponents: []string{
-				"mmproj-26b-bf16-gguf",   // seed: one component of 26b-q4-k-m-gguf model
-				"runtime-llama-cpp-cpu",  // required by cpu runtime; avoids runtime-install noise
+				"mmproj-26b-bf16-gguf",  // seed: one component of 26b-q4-k-m-gguf model
+				"runtime-llama-cpp-cpu", // required by cpu runtime; avoids runtime-install noise
 			},
 			engineScores: []struct {
 				name  string
@@ -436,7 +419,7 @@ func TestSwitchToPreinstalledEngineAndModel(t *testing.T) {
 			}
 
 			cmd := newUseEngineCmd()
-			switched, err := switchToPreinstalledEngineAndModel(cmd, scored)
+			switched, err := selectEngineForSeededComponents(cmd, scored)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -467,4 +450,3 @@ func TestSwitchToPreinstalledEngineAndModel(t *testing.T) {
 		})
 	}
 }
-

--- a/cmd/modelctl/common/component.go
+++ b/cmd/modelctl/common/component.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,6 +25,10 @@ func InstalledComponents() ([]string, error) {
 
 	entries, err := os.ReadDir(componentsDir)
 	if err != nil {
+		// If the components directory does not exist, it means no components are installed
+		if errors.Is(err, os.ErrNotExist) {
+			return []string{}, nil
+		}
 		return nil, fmt.Errorf("reading components directory %q: %v", componentsDir, err)
 	}
 

--- a/cmd/modelctl/common/component_test.go
+++ b/cmd/modelctl/common/component_test.go
@@ -358,12 +358,15 @@ func TestInstalledComponents(t *testing.T) {
 		}
 	})
 
-	t.Run("non-existent components directory returns error", func(t *testing.T) {
+	t.Run("non-existent components directory returns empty slice", func(t *testing.T) {
 		t.Setenv("SNAP_COMPONENTS", "/this/path/does/not/exist")
 
-		_, err := InstalledComponents()
-		if err == nil {
-			t.Fatal("expected error for non-existent components directory, got nil")
+		installed, err := InstalledComponents()
+		if err != nil {
+			t.Fatalf("expected nil error for non-existent components directory, got: %v", err)
+		}
+		if len(installed) != 0 {
+			t.Errorf("expected empty slice for non-existent components directory, got %v", installed)
 		}
 	})
 }

--- a/pkg/runtimes/types.go
+++ b/pkg/runtimes/types.go
@@ -3,7 +3,7 @@ package runtimes
 import "github.com/canonical/inference-snaps-cli/v2/pkg/types"
 
 type Manifest struct {
-	ID          string                  `json:"id" yaml:"id"`
+	Name        string                  `json:"name" yaml:"name"`
 	Servers     map[string]Server       `json:"servers" yaml:"servers"`
 	Environment []string                `json:"environment" yaml:"environment"`
 	Layout      map[string]types.Layout `yaml:"layout"`

--- a/pkg/runtimes/types.go
+++ b/pkg/runtimes/types.go
@@ -3,6 +3,7 @@ package runtimes
 import "github.com/canonical/inference-snaps-cli/v2/pkg/types"
 
 type Manifest struct {
+	ID          string                  `json:"id" yaml:"id"`
 	Servers     map[string]Server       `json:"servers" yaml:"servers"`
 	Environment []string                `json:"environment" yaml:"environment"`
 	Layout      map[string]types.Layout `yaml:"layout"`

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -35,4 +35,4 @@ ln -s /var/lib/snapd/hostfs/usr/lib/wsl/drivers $SNAP_COMMON/usr/lib/wsl/drivers
 #
 # Auto select an engine
 #
-modelctl use-engine --auto --assume-yes --fallback=cpu
+modelctl use-engine --auto --components --assume-yes --fallback=cpu

--- a/test_data/engines/cuda-generic/engine.yaml
+++ b/test_data/engines/cuda-generic/engine.yaml
@@ -13,3 +13,14 @@ devices:
       # model-ids: [ ]
       vram: 5G
       # compute-capability: 5.0
+
+runtime: llama-cpp-cuda
+
+model:
+  default: 26b-q4-k-m-gguf
+  options:
+    - 26b-q4-k-m-gguf
+    - 30b-a3b-q4-k-m-gguf
+
+configurations:
+  sleep-idle-seconds: 600

--- a/test_data/engines/rocm-generic/engine.yaml
+++ b/test_data/engines/rocm-generic/engine.yaml
@@ -14,3 +14,14 @@ devices:
     - type: gpu
       vendor-id: 0x1002 # AMD Corporation
       microarchitecture: gfx1030
+
+runtime: llama-cpp-rocm
+
+model:
+  default: 26b-q4-k-m-gguf
+  options:
+    - 26b-q4-k-m-gguf
+    - 30b-a3b-q4-k-m-gguf
+
+configurations:
+  sleep-idle-seconds: 600

--- a/test_data/models/26b-q4-k-m-gguf/model.yaml
+++ b/test_data/models/26b-q4-k-m-gguf/model.yaml
@@ -1,4 +1,4 @@
-id: 26b-a4b-it-q4-k-m-gguf
+id: 26b-q4-k-m-gguf
 name: 26b
 
 description: Test model description

--- a/test_data/runtimes/llama-cpp-cpu/runtime.yaml
+++ b/test_data/runtimes/llama-cpp-cpu/runtime.yaml
@@ -1,4 +1,4 @@
-id: llama-cpp-cpu
+name: llama-cpp-cpu
 
 servers:
   openai:

--- a/test_data/runtimes/llama-cpp-cpu/runtime.yaml
+++ b/test_data/runtimes/llama-cpp-cpu/runtime.yaml
@@ -1,3 +1,5 @@
+id: llama-cpp-cpu
+
 servers:
   openai:
     protocol: http

--- a/test_data/runtimes/llama-cpp-cpu/runtime.yaml
+++ b/test_data/runtimes/llama-cpp-cpu/runtime.yaml
@@ -7,11 +7,11 @@ servers:
 
 environment:
   # Add llama.cpp binaries
-  - PATH=$PATH:$SNAP_COMPONENTS/llama-cpp-cuda/bin
+  - PATH=$PATH:$SNAP_COMPONENTS/runtime-llama-cpp-cpu/bin
   # Add llama.cpp-built shared libraries
-  - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP_COMPONENTS/llama-cpp-cuda/lib
+  - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP_COMPONENTS/runtime-llama-cpp-cpu/lib
   # Add staged shared libraries
-  - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP_COMPONENTS/llama-cpp-cuda/usr/lib/$ARCH_TRIPLET
+  - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP_COMPONENTS/runtime-llama-cpp-cpu/usr/lib/$ARCH_TRIPLET
 
 components:
   - runtime-llama-cpp-cpu

--- a/test_data/runtimes/llama-cpp-cuda/runtime.yaml
+++ b/test_data/runtimes/llama-cpp-cuda/runtime.yaml
@@ -1,3 +1,5 @@
+id: llama-cpp-cuda
+
 servers:
   openai:
     protocol: http

--- a/test_data/runtimes/llama-cpp-cuda/runtime.yaml
+++ b/test_data/runtimes/llama-cpp-cuda/runtime.yaml
@@ -1,4 +1,4 @@
-id: llama-cpp-cuda
+name: llama-cpp-cuda
 
 servers:
   openai:

--- a/test_data/runtimes/llama-cpp-cuda/runtime.yaml
+++ b/test_data/runtimes/llama-cpp-cuda/runtime.yaml
@@ -14,4 +14,4 @@ environment:
   - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP_COMPONENTS/llama-cpp-cuda/usr/lib/$ARCH_TRIPLET
 
 components:
-  - llama-cpp-cuda
+  - runtime-llama-cpp-cuda

--- a/test_data/runtimes/llama-cpp-cuda/runtime.yaml
+++ b/test_data/runtimes/llama-cpp-cuda/runtime.yaml
@@ -7,11 +7,11 @@ servers:
 
 environment:
   # Add llama.cpp binaries
-  - PATH=$PATH:$SNAP_COMPONENTS/llama-cpp-cuda/bin
+  - PATH=$PATH:$SNAP_COMPONENTS/runtime-llama-cpp-cuda/bin
   # Add llama.cpp-built shared libraries
-  - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP_COMPONENTS/llama-cpp-cuda/lib
+  - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP_COMPONENTS/runtime-llama-cpp-cuda/lib
   # Add staged shared libraries
-  - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP_COMPONENTS/llama-cpp-cuda/usr/lib/$ARCH_TRIPLET
+  - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP_COMPONENTS/runtime-llama-cpp-cuda/usr/lib/$ARCH_TRIPLET
 
 components:
   - runtime-llama-cpp-cuda

--- a/test_data/runtimes/llama-cpp-rocm/runtime.yaml
+++ b/test_data/runtimes/llama-cpp-rocm/runtime.yaml
@@ -1,3 +1,5 @@
+id: llama-cpp-rocm
+
 servers:
   openai:
     protocol: http

--- a/test_data/runtimes/llama-cpp-rocm/runtime.yaml
+++ b/test_data/runtimes/llama-cpp-rocm/runtime.yaml
@@ -1,4 +1,4 @@
-id: llama-cpp-rocm
+name: llama-cpp-rocm
 
 servers:
   openai:

--- a/test_data/runtimes/llama-cpp-rocm/runtime.yaml
+++ b/test_data/runtimes/llama-cpp-rocm/runtime.yaml
@@ -14,4 +14,4 @@ environment:
   - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP_COMPONENTS/llama-cpp-cuda/usr/lib/$ARCH_TRIPLET
 
 components:
-  - llama-cpp-cuda
+  - runtime-llama-cpp-rocm

--- a/test_data/runtimes/llama-cpp-rocm/runtime.yaml
+++ b/test_data/runtimes/llama-cpp-rocm/runtime.yaml
@@ -7,11 +7,11 @@ servers:
 
 environment:
   # Add llama.cpp binaries
-  - PATH=$PATH:$SNAP_COMPONENTS/llama-cpp-cuda/bin
+  - PATH=$PATH:$SNAP_COMPONENTS/runtime-llama-cpp-rocm/bin
   # Add llama.cpp-built shared libraries
-  - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP_COMPONENTS/llama-cpp-cuda/lib
+  - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP_COMPONENTS/runtime-llama-cpp-rocm/lib
   # Add staged shared libraries
-  - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP_COMPONENTS/llama-cpp-cuda/usr/lib/$ARCH_TRIPLET
+  - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SNAP_COMPONENTS/runtime-llama-cpp-rocm/usr/lib/$ARCH_TRIPLET
 
 components:
   - runtime-llama-cpp-rocm

--- a/test_data/runtimes/openvino-model-server/runtime.yaml
+++ b/test_data/runtimes/openvino-model-server/runtime.yaml
@@ -1,3 +1,5 @@
+id: openvino-model-server
+
 servers:
   tensorflow-serving:
     protocol: http

--- a/test_data/runtimes/openvino-model-server/runtime.yaml
+++ b/test_data/runtimes/openvino-model-server/runtime.yaml
@@ -1,4 +1,4 @@
-id: openvino-model-server
+name: openvino-model-server
 
 servers:
   tensorflow-serving:


### PR DESCRIPTION
This PR can be tested using `gemma4` from `latest/edge/pr-69`. A summary of tests that were done on it can be seen in [the PR description](https://github.com/canonical/gemma4-snap/pull/69).

The following has not been implemented exactly as specified. The current behaviour is that all seeded runtimes and all seeded models translate to a list of engines. These engines are sorted by score, and the highest scoring engine from this list is selected.

> If more than one model or more than one runtime is installed with the snap, ignore all. This is to ensure that the system doesn’t change the selection mechanism when the user’s intention is to simply have multiple things installed to switch over later (e.g. UC image with several components for offline use).

### Breaking changes

* Runtime manifests require an `id` field, with the value matching the runtime directory name.