### PR TITLE
Allow model override in `switchEngine`

### DIFF
--- a/cmd/modelctl/commands/use-engine.go
+++ b/cmd/modelctl/commands/use-engine.go
@@ -177,7 +177,7 @@ func (cmd *useEngineCommand) autoSelectScoredEngine(scoredEngines []engines.Scor
 // switchEngine changes the engine that is used by the snap
 // By default the previous model will be used if it is compatible.
 // If it is not compatible, the engine's default model will be selected.
-// And optional modelName can be provided to override which model is switched to.
+// An optional modelName can be provided to override the model used for the switch.
 func (cmd *useEngineCommand) switchEngine(engineName string, modelName string) error {
 
 	newEngineManifest, err := engines.LoadManifest(cmd.EnginesDir, engineName)

--- a/cmd/modelctl/commands/use-engine.go
+++ b/cmd/modelctl/commands/use-engine.go
@@ -101,7 +101,7 @@ func (cmd *useEngineCommand) run(_ *cobra.Command, args []string) error {
 		return err
 	} else {
 		if len(args) == 1 {
-			return cmd.switchEngine(args[0])
+			return cmd.switchEngine(args[0], "")
 		} else {
 			return fmt.Errorf("engine name not specified")
 		}
@@ -116,7 +116,7 @@ func (cmd *useEngineCommand) autoSelectEngine() error {
 
 	if !observable && cmd.fallback != "" {
 		fmt.Printf("Hardware information is unavailable; falling back to engine %q.\n", cmd.fallback)
-		return cmd.switchEngine(cmd.fallback)
+		return cmd.switchEngine(cmd.fallback, "")
 	}
 
 	scoredEngines, err := common.ScoreEnginesWithSpinner(cmd.Context)
@@ -166,7 +166,7 @@ func (cmd *useEngineCommand) autoSelectScoredEngine(scoredEngines []engines.Scor
 
 	fmt.Printf("Selected engine: %s\n", selectedEngine.Name)
 
-	err = cmd.switchEngine(selectedEngine.Name)
+	err = cmd.switchEngine(selectedEngine.Name, "")
 	if err != nil {
 		return fmt.Errorf("use engine: %s", err)
 	}
@@ -175,7 +175,10 @@ func (cmd *useEngineCommand) autoSelectScoredEngine(scoredEngines []engines.Scor
 }
 
 // switchEngine changes the engine that is used by the snap
-func (cmd *useEngineCommand) switchEngine(engineName string) error {
+// By default the previous model will be used if it is compatible.
+// If it is not compatible, the engine's default model will be selected.
+// And optional modelName can be provided to override which model is switched to.
+func (cmd *useEngineCommand) switchEngine(engineName string, modelName string) error {
 
 	newEngineManifest, err := engines.LoadManifest(cmd.EnginesDir, engineName)
 	if err != nil {
@@ -201,6 +204,11 @@ func (cmd *useEngineCommand) switchEngine(engineName string) error {
 	newModelName := activeModelName
 	if !slices.Contains(newEngineManifest.Model.Options, activeModelName) {
 		newModelName = newEngineManifest.Model.Default
+	}
+
+	// If a model name is provided, use that one instead
+	if modelName != "" && slices.Contains(newEngineManifest.Model.Options, modelName) {
+		newModelName = modelName
 	}
 
 	var newModelManifest *models.Manifest
@@ -466,7 +474,7 @@ func selectEngineForSeededComponents(cmd *useEngineCommand, scoredEngines []engi
 	if err != nil {
 		return false, fmt.Errorf("finding top engine: %v", err)
 	}
-	fmt.Printf("Top engine: %v\n", topEngine.Name)
+	fmt.Printf("Using seeded engine: %v\n", topEngine.Name)
 
 	// If multiple models were seeded, prefer the engine's default
 	seededModelForEngine := ""
@@ -479,16 +487,11 @@ func selectEngineForSeededComponents(cmd *useEngineCommand, scoredEngines []engi
 		}
 	}
 
-	// If a model was seeded, switch to it. Otherwise, switchEngine() will use the default model.
 	if seededModelForEngine != "" {
-		fmt.Printf("Seeded model for engine: %v\n", seededModelForEngine)
-		err = cmd.Cache.SetActiveModel(seededModelForEngine)
-		if err != nil {
-			return false, fmt.Errorf("setting active model: %v", err)
-		}
+		fmt.Printf("Using seeded model: %v\n", seededModelForEngine)
 	}
 
-	err = cmd.switchEngine(topEngine.Name)
+	err = cmd.switchEngine(topEngine.Name, seededModelForEngine)
 	if err != nil {
 		return false, fmt.Errorf("switching engine: %v", err)
 	}

--- a/cmd/modelctl/commands/use-engine.go
+++ b/cmd/modelctl/commands/use-engine.go
@@ -206,8 +206,11 @@ func (cmd *useEngineCommand) switchEngine(engineName string, modelName string) e
 		newModelName = newEngineManifest.Model.Default
 	}
 
-	// If a model name is provided, use that one instead
-	if modelName != "" && slices.Contains(newEngineManifest.Model.Options, modelName) {
+	// If a model name is provided, it must be supported by the new engine.
+	if modelName != "" {
+		if !slices.Contains(newEngineManifest.Model.Options, modelName) {
+			return fmt.Errorf("model %q is not supported by engine %q", modelName, engineName)
+		}
 		newModelName = modelName
 	}
 

--- a/cmd/modelctl/commands/use-engine.go
+++ b/cmd/modelctl/commands/use-engine.go
@@ -101,7 +101,7 @@ func (cmd *useEngineCommand) run(_ *cobra.Command, args []string) error {
 		return err
 	} else {
 		if len(args) == 1 {
-			return cmd.switchEngine(args[0], "")
+			return cmd.switchEngine(args[0])
 		} else {
 			return fmt.Errorf("engine name not specified")
 		}
@@ -116,7 +116,7 @@ func (cmd *useEngineCommand) autoSelectEngine() error {
 
 	if !observable && cmd.fallback != "" {
 		fmt.Printf("Hardware information is unavailable; falling back to engine %q.\n", cmd.fallback)
-		return cmd.switchEngine(cmd.fallback, "")
+		return cmd.switchEngine(cmd.fallback)
 	}
 
 	scoredEngines, err := common.ScoreEnginesWithSpinner(cmd.Context)
@@ -166,7 +166,7 @@ func (cmd *useEngineCommand) autoSelectScoredEngine(scoredEngines []engines.Scor
 
 	fmt.Printf("Selected engine: %s\n", selectedEngine.Name)
 
-	err = cmd.switchEngine(selectedEngine.Name, "")
+	err = cmd.switchEngine(selectedEngine.Name)
 	if err != nil {
 		return fmt.Errorf("use engine: %s", err)
 	}
@@ -174,12 +174,10 @@ func (cmd *useEngineCommand) autoSelectScoredEngine(scoredEngines []engines.Scor
 	return nil
 }
 
-// switchEngine changes the engine that is used by the snap
-// By default the previous model will be used if it is compatible.
+// switchEngine changes the engine and model used by the snap
+// By default, the previous model will be used if it is compatible.
 // If it is not compatible, the engine's default model will be selected.
-// An optional modelID can be provided to override the model used for the switch.
-func (cmd *useEngineCommand) switchEngine(engineName string, modelID string) error {
-
+func (cmd *useEngineCommand) switchEngine(engineName string) error {
 	newEngineManifest, err := engines.LoadManifest(cmd.EnginesDir, engineName)
 	if err != nil {
 		if errors.Is(err, engines.ErrManifestNotFound) {
@@ -196,22 +194,50 @@ func (cmd *useEngineCommand) switchEngine(engineName string, modelID string) err
 		return fmt.Errorf("getting active model: %v", err)
 	}
 
-	// If the current active model is not supported by the new engine, switch to the new engine's default model
-	newModelID := activeModelID
-	if !slices.Contains(newEngineManifest.Model.Options, activeModelID) {
+	newModelID := ""
+	if slices.Contains(newEngineManifest.Model.Options, activeModelID) {
+		newModelID = activeModelID
+	} else {
 		newModelID = newEngineManifest.Model.Default
 	}
 
-	// If a model ID is provided, use that instead
-	if modelID != "" {
-		if !slices.Contains(newEngineManifest.Model.Options, modelID) {
-			return fmt.Errorf("model %q is not supported by engine %q", modelID, engineName)
+	return cmd.switchEngineAndModel(engineName, newModelID)
+}
+
+// switchEngineAndModel changes the engine and model used by the snap
+// An error is returned if the model is not supported by the engine
+func (cmd *useEngineCommand) switchEngineAndModel(newEngineName string, newModelID string) error {
+
+	activeEngineName, err := cmd.Cache.GetActiveEngine()
+	if err != nil {
+		return fmt.Errorf("%s: %w", common.LookingUpActiveEngine, err)
+	}
+
+	activeModelID, err := cmd.Cache.GetActiveModel()
+	if err != nil {
+		return fmt.Errorf("getting active model: %v", err)
+	}
+
+	newEngineManifest, err := engines.LoadManifest(cmd.EnginesDir, newEngineName)
+	if err != nil {
+		if errors.Is(err, engines.ErrManifestNotFound) {
+			if cmd.Verbose {
+				fmt.Println(err)
+			}
+			return fmt.Errorf("%q not found", newEngineName)
 		}
-		newModelID = modelID
+		return fmt.Errorf("loading engine manifest: %v", err)
 	}
 
 	var newModelManifest *models.Manifest
+
+	// It is optional for engines to define a model
+	// The options slice can therefore be empty, and the default model ID can be an empty string
 	if newModelID != "" {
+		if !slices.Contains(newEngineManifest.Model.Options, newModelID) {
+			return fmt.Errorf("model %q is not supported by engine %q", newModelID, newEngineName)
+		}
+
 		newModelManifest, err = models.LoadManifest(cmd.ModelsDir, newModelID)
 		if err != nil {
 			return fmt.Errorf("loading model manifest: %v", err)
@@ -227,17 +253,7 @@ func (cmd *useEngineCommand) switchEngine(engineName string, modelID string) err
 		return nil
 	}
 
-	err = cmd.Cache.SetActiveModel(newModelID)
-	if err != nil {
-		return fmt.Errorf("setting active model: %v", err)
-	}
-
-	activeEngineName, err := cmd.Cache.GetActiveEngine()
-	if err != nil {
-		return fmt.Errorf("%s: %w", common.LookingUpActiveEngine, err)
-	}
-
-	if activeEngineName == engineName && activeModelID == newModelID {
+	if activeEngineName == newEngineName && activeModelID == newModelID {
 		// Neither engine nor model changed. Nothing left to do.
 		return nil
 	}
@@ -258,7 +274,15 @@ func (cmd *useEngineCommand) switchEngine(engineName string, modelID string) err
 		return fmt.Errorf("setting new engine configurations: %v", err)
 	}
 
-	fmt.Printf("Engine changed to %q.\n", engineName)
+	err = cmd.Cache.SetActiveModel(newModelID)
+	if err != nil {
+		return fmt.Errorf("setting active model: %v", err)
+	}
+
+	fmt.Printf("Engine changed to %q.\n", newEngineName)
+	if newModelID != "" && activeModelID != newModelID {
+		fmt.Printf("Model changed to %q.\n", newModelID)
+	}
 
 	// Ask if the user wants to restart
 	if !cmd.noRestart {
@@ -490,7 +514,7 @@ func selectEngineForSeededComponents(cmd *useEngineCommand, scoredEngines []engi
 		fmt.Printf("Using seeded model: %v\n", seededModelForEngine)
 	}
 
-	err = cmd.switchEngine(topEngine.Name, seededModelForEngine)
+	err = cmd.switchEngineAndModel(topEngine.Name, seededModelForEngine)
 	if err != nil {
 		return false, fmt.Errorf("switching engine: %v", err)
 	}

--- a/cmd/modelctl/commands/use-engine.go
+++ b/cmd/modelctl/commands/use-engine.go
@@ -510,13 +510,17 @@ func selectEngineForSeededComponents(cmd *useEngineCommand, scoredEngines []engi
 		}
 	}
 
-	if seededModelForEngine != "" {
+	if seededModelForEngine == "" {
+		err = cmd.switchEngine(topEngine.Name)
+		if err != nil {
+			return false, fmt.Errorf("switching engine: %v", err)
+		}
+	} else {
 		fmt.Printf("Using seeded model: %v\n", seededModelForEngine)
-	}
-
-	err = cmd.switchEngineAndModel(topEngine.Name, seededModelForEngine)
-	if err != nil {
-		return false, fmt.Errorf("switching engine: %v", err)
+		err = cmd.switchEngineAndModel(topEngine.Name, seededModelForEngine)
+		if err != nil {
+			return false, fmt.Errorf("switching engine and model: %v", err)
+		}
 	}
 
 	return true, nil

--- a/cmd/modelctl/commands/use-engine.go
+++ b/cmd/modelctl/commands/use-engine.go
@@ -196,7 +196,7 @@ func (cmd *useEngineCommand) switchEngine(engineName string, modelID string) err
 		return fmt.Errorf("getting active model: %v", err)
 	}
 
-	// If the current active model is not supported by the new engine, switch to the engine's default model
+	// If the current active model is not supported by the new engine, switch to the new engine's default model
 	newModelID := activeModelID
 	if !slices.Contains(newEngineManifest.Model.Options, activeModelID) {
 		newModelID = newEngineManifest.Model.Default
@@ -238,7 +238,7 @@ func (cmd *useEngineCommand) switchEngine(engineName string, modelID string) err
 	}
 
 	if activeEngineName == engineName && activeModelID == newModelID {
-		// Engine not changed, nothing left to do
+		// Neither engine nor model changed. Nothing left to do.
 		return nil
 	}
 

--- a/cmd/modelctl/commands/use-engine.go
+++ b/cmd/modelctl/commands/use-engine.go
@@ -177,8 +177,8 @@ func (cmd *useEngineCommand) autoSelectScoredEngine(scoredEngines []engines.Scor
 // switchEngine changes the engine that is used by the snap
 // By default the previous model will be used if it is compatible.
 // If it is not compatible, the engine's default model will be selected.
-// An optional modelName can be provided to override the model used for the switch.
-func (cmd *useEngineCommand) switchEngine(engineName string, modelName string) error {
+// And optional modelID can be provided to override which model is switched to.
+func (cmd *useEngineCommand) switchEngine(engineName string, modelID string) error {
 
 	newEngineManifest, err := engines.LoadManifest(cmd.EnginesDir, engineName)
 	if err != nil {
@@ -191,32 +191,28 @@ func (cmd *useEngineCommand) switchEngine(engineName string, modelName string) e
 		return fmt.Errorf("loading engine manifest: %v", err)
 	}
 
-	// We need to check which components are required for the switch.
-	// If the current model is supported by the new engine, we use the active model's components.
-	// If the model is not supported, we need to use the components of the new engine's default model.
-
-	activeModelName, err := cmd.Cache.GetActiveModel()
+	activeModelID, err := cmd.Cache.GetActiveModel()
 	if err != nil {
-		return fmt.Errorf("getting active model name: %v", err)
+		return fmt.Errorf("getting active model: %v", err)
 	}
 
 	// If the current active model is not supported by the new engine, switch to the engine's default model
-	newModelName := activeModelName
-	if !slices.Contains(newEngineManifest.Model.Options, activeModelName) {
-		newModelName = newEngineManifest.Model.Default
+	newModelID := activeModelID
+	if !slices.Contains(newEngineManifest.Model.Options, activeModelID) {
+		newModelID = newEngineManifest.Model.Default
 	}
 
-	// If a model name is provided, it must be supported by the new engine.
-	if modelName != "" {
-		if !slices.Contains(newEngineManifest.Model.Options, modelName) {
-			return fmt.Errorf("model %q is not supported by engine %q", modelName, engineName)
+	// If a model ID is provided, use that instead
+	if modelID != "" {
+		if !slices.Contains(newEngineManifest.Model.Options, modelID) {
+			return fmt.Errorf("model %q is not supported by engine %q", modelID, engineName)
 		}
-		newModelName = modelName
+		newModelID = modelID
 	}
 
 	var newModelManifest *models.Manifest
-	if newModelName != "" {
-		newModelManifest, err = models.LoadManifest(cmd.ModelsDir, newModelName)
+	if newModelID != "" {
+		newModelManifest, err = models.LoadManifest(cmd.ModelsDir, newModelID)
 		if err != nil {
 			return fmt.Errorf("loading model manifest: %v", err)
 		}
@@ -231,7 +227,7 @@ func (cmd *useEngineCommand) switchEngine(engineName string, modelName string) e
 		return nil
 	}
 
-	err = cmd.Cache.SetActiveModel(newModelName)
+	err = cmd.Cache.SetActiveModel(newModelID)
 	if err != nil {
 		return fmt.Errorf("setting active model: %v", err)
 	}

--- a/cmd/modelctl/commands/use-engine.go
+++ b/cmd/modelctl/commands/use-engine.go
@@ -177,7 +177,7 @@ func (cmd *useEngineCommand) autoSelectScoredEngine(scoredEngines []engines.Scor
 // switchEngine changes the engine that is used by the snap
 // By default the previous model will be used if it is compatible.
 // If it is not compatible, the engine's default model will be selected.
-// And optional modelID can be provided to override which model is switched to.
+// An optional modelID can be provided to override the model used for the switch.
 func (cmd *useEngineCommand) switchEngine(engineName string, modelID string) error {
 
 	newEngineManifest, err := engines.LoadManifest(cmd.EnginesDir, engineName)

--- a/cmd/modelctl/commands/use-engine.go
+++ b/cmd/modelctl/commands/use-engine.go
@@ -237,7 +237,7 @@ func (cmd *useEngineCommand) switchEngine(engineName string, modelID string) err
 		return fmt.Errorf("%s: %w", common.LookingUpActiveEngine, err)
 	}
 
-	if activeEngineName == engineName {
+	if activeEngineName == engineName && activeModelID == newModelID {
 		// Engine not changed, nothing left to do
 		return nil
 	}

--- a/cmd/modelctl/commands/use-engine_test.go
+++ b/cmd/modelctl/commands/use-engine_test.go
@@ -93,7 +93,7 @@ func ExampleUseEngine_noRestartWhenEngineUnchanged() {
 		},
 	}
 
-	if err := cmd.switchEngine("intel-gpu"); err != nil {
+	if err := cmd.switchEngine("intel-gpu", ""); err != nil {
 		panic(err)
 	}
 
@@ -114,7 +114,7 @@ func ExampleUseEngine_restartWhenEngineChanged() {
 		},
 	}
 
-	if err := cmd.switchEngine("cpu-avx1"); err != nil {
+	if err := cmd.switchEngine("cpu-avx1", ""); err != nil {
 		panic(err)
 	}
 

--- a/cmd/modelctl/commands/use-engine_test.go
+++ b/cmd/modelctl/commands/use-engine_test.go
@@ -92,7 +92,7 @@ func ExampleUseEngine_noRestartWhenEngineAndModelUnchanged() {
 		},
 	}
 
-	if err := cmd.switchEngine("intel-gpu", ""); err != nil {
+	if err := cmd.switchEngine("intel-gpu"); err != nil {
 		panic(err)
 	}
 
@@ -113,7 +113,7 @@ func ExampleUseEngine_restartWhenEngineChanged() {
 		},
 	}
 
-	if err := cmd.switchEngine("cpu-avx1", ""); err != nil {
+	if err := cmd.switchEngine("cpu-avx1"); err != nil {
 		panic(err)
 	}
 
@@ -187,6 +187,7 @@ func ExampleUseEngine_autoSelectEngine() {
 	// ✔ cpu: compatible, score=10
 	// Selected engine: cpu
 	// Engine changed to "cpu".
+	// Model changed to "26b-q4-k-m-gguf".
 	// [mock] Restarting all services
 }
 
@@ -258,7 +259,7 @@ func TestSwitchEngine_withModelID(t *testing.T) {
 			setupSnapComponents(t, tt.installedComponents...)
 
 			cmd := newUseEngineCmd()
-			err := cmd.switchEngine(tt.engineName, tt.modelID)
+			err := cmd.switchEngineAndModel(tt.engineName, tt.modelID)
 
 			if tt.wantErr {
 				if err == nil {

--- a/cmd/modelctl/commands/use-engine_test.go
+++ b/cmd/modelctl/commands/use-engine_test.go
@@ -190,6 +190,107 @@ func ExampleUseEngine_autoSelectEngine() {
 	// Engine changed to "cpu".
 	// [mock] Restarting all services
 }
+
+// TestSwitchEngine_withModelID verifies that switchEngine respects an
+// explicitly supplied modelID:
+//   - a valid model supported by the engine is persisted as the active model
+//   - an unsupported model returns an error and leaves state unchanged
+func TestSwitchEngine_withModelID(t *testing.T) {
+	tests := []struct {
+		name                string
+		engineName          string
+		modelID             string
+		installedComponents []string
+		wantErr             bool
+		wantEngine          string
+		wantModel           string
+	}{
+		{
+			// Switch to the cpu engine and explicitly request the non-default
+			// model (30b-a3b-q4-k-m-gguf).  The engine's default is
+			// 26b-q4-k-m-gguf, so this exercises the override branch.
+			name:       "valid non-default model is used",
+			engineName: "cpu",
+			modelID:    "30b-a3b-q4-k-m-gguf",
+			installedComponents: []string{
+				"runtime-llama-cpp-cpu",
+				"model-30b-a3b-q4-k-m-gguf-1-of-6",
+				"model-30b-a3b-q4-k-m-gguf-2-of-6",
+				"model-30b-a3b-q4-k-m-gguf-3-of-6",
+				"model-30b-a3b-q4-k-m-gguf-4-of-6",
+				"model-30b-a3b-q4-k-m-gguf-5-of-6",
+				"model-30b-a3b-q4-k-m-gguf-6-of-6",
+			},
+			wantErr:    false,
+			wantEngine: "cpu",
+			wantModel:  "30b-a3b-q4-k-m-gguf",
+		},
+		{
+			// Switch to the cpu engine and explicitly request the default model
+			// (26b-q4-k-m-gguf) – this should also succeed and store the
+			// explicit choice.
+			name:       "valid default model is used",
+			engineName: "cpu",
+			modelID:    "26b-q4-k-m-gguf",
+			installedComponents: []string{
+				"runtime-llama-cpp-cpu",
+				"model-26b-a4b-q4-k-m-gguf",
+				"mmproj-26b-bf16-gguf",
+			},
+			wantErr:    false,
+			wantEngine: "cpu",
+			wantModel:  "26b-q4-k-m-gguf",
+		},
+		{
+			// Request a model that the cpu engine does not support.
+			// switchEngine must return an error and must not change any state.
+			name:       "unsupported model returns error",
+			engineName: "cpu",
+			modelID:    "4b-it-int4-fq-ov", // only supported by intel-gpu
+			installedComponents: []string{
+				"runtime-llama-cpp-cpu",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupSnapComponents(t, tt.installedComponents...)
+
+			cmd := newUseEngineCmd()
+			err := cmd.switchEngine(tt.engineName, tt.modelID)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error but got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			activeEngine, err := cmd.Cache.GetActiveEngine()
+			if err != nil {
+				t.Fatalf("getting active engine: %v", err)
+			}
+			if activeEngine != tt.wantEngine {
+				t.Errorf("active engine = %q, want %q", activeEngine, tt.wantEngine)
+			}
+
+			activeModel, err := cmd.Cache.GetActiveModel()
+			if err != nil {
+				t.Fatalf("getting active model: %v", err)
+			}
+			if activeModel != tt.wantModel {
+				t.Errorf("active model = %q, want %q", activeModel, tt.wantModel)
+			}
+		})
+	}
+}
+
 func TestFixActiveEngine_noActiveEngine(t *testing.T) {
 	cache := storage.NewMockCache()
 	cmd := useEngineCommand{

--- a/cmd/modelctl/commands/use-engine_test.go
+++ b/cmd/modelctl/commands/use-engine_test.go
@@ -60,9 +60,7 @@ func loadScoredEngine(t *testing.T, name string, score int) engines.ScoredManife
 	return engines.ScoredManifest{Manifest: *m, Score: score}
 }
 
-func ExampleUseEngine_noRestartWhenEngineUnchanged() {
-	// intel-gpu now requires runtime and model components, so we need SNAP_COMPONENTS
-	// to be set with those component directories so InstallMissingComponents is a no-op.
+func ExampleUseEngine_noRestartWhenEngineAndModelUnchanged() {
 	snapComponents, err := os.MkdirTemp("", "snap-components-*")
 	if err != nil {
 		panic(err)
@@ -80,6 +78,7 @@ func ExampleUseEngine_noRestartWhenEngineUnchanged() {
 
 	cache := storage.NewMockCache()
 	cache.SetActiveEngine("intel-gpu")
+	cache.SetActiveModel("4b-it-int4-fq-ov")
 	config := storage.NewMockConfig()
 	cmd := useEngineCommand{
 		assumeYes: true,

--- a/cmd/modelctl/commands/use-engine_test.go
+++ b/cmd/modelctl/commands/use-engine_test.go
@@ -191,7 +191,7 @@ func ExampleUseEngine_autoSelectEngine() {
 	// [mock] Restarting all services
 }
 
-// TestSwitchEngine_withModelID verifies that switchEngine respects an
+// TestSwitchEngine_withModelID verifies that switchEngineAndModel respects an
 // explicitly supplied modelID:
 //   - a valid model supported by the engine is persisted as the active model
 //   - an unsupported model returns an error and leaves state unchanged

--- a/pkg/models/load.go
+++ b/pkg/models/load.go
@@ -45,9 +45,9 @@ func LoadManifests(manifestsDir string) ([]Manifest, error) {
 	return manifests, nil
 }
 
-func LoadManifest(manifestsDir, modelName string) (*Manifest, error) {
+func LoadManifest(manifestsDir, modelID string) (*Manifest, error) {
 
-	fileName := filepath.Join(manifestsDir, modelName, ManifestFilename)
+	fileName := filepath.Join(manifestsDir, modelID, ManifestFilename)
 	data, err := os.ReadFile(fileName)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -59,7 +59,7 @@ func LoadManifest(manifestsDir, modelName string) (*Manifest, error) {
 	var manifest Manifest
 	err = yaml.Unmarshal(data, &manifest)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %s", manifestsDir, err)
+		return nil, fmt.Errorf("%s: %s", fileName, err)
 	}
 
 	return &manifest, nil


### PR DESCRIPTION
This PR addresses the concern from https://github.com/canonical/inference-snaps-cli/pull/385#discussion_r3460600996

Switch engine should be explicitly told which model to switch to in some situations. We should not depend on the active model being set as having this as a side effect.