### PR TITLE
Reject dots in environment variable names

### DIFF
--- a/cmd/modelctl/commands/run.go
+++ b/cmd/modelctl/commands/run.go
@@ -86,7 +86,10 @@ func (cmd *runCommand) processEnvConfigs() error {
 	envVars := make(map[string]any, len(envConfigs))
 	for k, v := range envConfigs {
 		// Convert env keys (my-key) to environment variable names (MY_KEY)
-		name := strings.TrimPrefix(k, storage.EnvKeyPrefix)
+		name, ok := strings.CutPrefix(k, storage.EnvKeyPrefix)
+		if !ok {
+			return fmt.Errorf("unexpected config key %q: expected prefix %q", k, storage.EnvKeyPrefix)
+		}
 		name = strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
 		envVars[name] = fmt.Sprintf("%v", v)
 	}

--- a/cmd/modelctl/commands/run.go
+++ b/cmd/modelctl/commands/run.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/canonical/inference-snaps-cli/v2/cmd/modelctl/common"
+	"github.com/canonical/inference-snaps-cli/v2/pkg/storage"
 	"github.com/canonical/inference-snaps-cli/v2/pkg/utils"
 	"github.com/spf13/cobra"
 )
@@ -82,11 +83,10 @@ func (cmd *runCommand) processEnvConfigs() error {
 		return fmt.Errorf("getting configs: %v", err)
 	}
 
-	const keyPrefix = "env."
 	envVars := make(map[string]any, len(envConfigs))
 	for k, v := range envConfigs {
 		// Convert env keys (my-key) to environment variable names (MY_KEY)
-		name := strings.TrimPrefix(k, keyPrefix)
+		name := strings.TrimPrefix(k, storage.EnvKeyPrefix)
 		name = strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
 		envVars[name] = fmt.Sprintf("%v", v)
 	}

--- a/cmd/modelctl/commands/set.go
+++ b/cmd/modelctl/commands/set.go
@@ -133,9 +133,10 @@ func (cmd *setCommand) setUserConfigs(keyValues map[string]string) error {
 	return nil
 }
 
-// validateEnvKeys rejects env keys that would result in environment variable
-// names that are not POSIX-compliant. Dots are not allowed because they are
-// not valid characters in environment variable names.
+// validateEnvKeys rejects env keys that would result in invalid environment
+// variable names. The name (the part after the env prefix) must not be empty
+// and must not contain dots, since dots are not valid characters in
+// environment variable names.
 func validateEnvKeys(keyValues map[string]string) error {
 	for key := range keyValues {
 		name, ok := strings.CutPrefix(key, storage.EnvKeyPrefix)

--- a/cmd/modelctl/commands/set.go
+++ b/cmd/modelctl/commands/set.go
@@ -142,6 +142,9 @@ func validateEnvKeys(keyValues map[string]string) error {
 		if !ok {
 			continue
 		}
+		if name == "" {
+			return fmt.Errorf("invalid key %q: environment variable name must not be empty", key)
+		}
 		if strings.Contains(name, ".") {
 			return fmt.Errorf("invalid key %q: dots are not allowed in environment variable names", key)
 		}

--- a/cmd/modelctl/commands/set.go
+++ b/cmd/modelctl/commands/set.go
@@ -62,6 +62,10 @@ func (cmd *setCommand) set(keyValuePairs []string) error {
 		return err
 	}
 
+	if err := validateEnvKeys(keyValues); err != nil {
+		return err
+	}
+
 	switch {
 	case cmd.packageConfig:
 		return cmd.setPackageConfigs(keyValues)
@@ -129,6 +133,22 @@ func (cmd *setCommand) setUserConfigs(keyValues map[string]string) error {
 	return nil
 }
 
+// validateEnvKeys rejects env keys that would result in environment variable
+// names that are not POSIX-compliant. Dots are not allowed because they are
+// not valid characters in environment variable names.
+func validateEnvKeys(keyValues map[string]string) error {
+	for key := range keyValues {
+		name, ok := strings.CutPrefix(key, storage.EnvKeyPrefix)
+		if !ok {
+			continue
+		}
+		if strings.Contains(name, ".") {
+			return fmt.Errorf("invalid key %q: dots are not allowed in environment variable names", key)
+		}
+	}
+	return nil
+}
+
 func (cmd *setCommand) parseKeyValues(keyValues []string) (map[string]string, error) {
 	kvMap := map[string]string{}
 	seenKeys := map[string]bool{}
@@ -171,7 +191,7 @@ func (cmd *setCommand) getCurrentValue(key string) (string, bool, error) {
 		return "", false, fmt.Errorf("checking existing keys: %s", err)
 	}
 	currVal, found := currValMap[key]
-	if !found && !strings.HasPrefix(key, "env.") {
+	if !found && !strings.HasPrefix(key, storage.EnvKeyPrefix) {
 		return "", false, fmt.Errorf("key %q is not found\n\n%s", key, common.SuggestKeyNotFound(key))
 	}
 

--- a/cmd/modelctl/commands/set_test.go
+++ b/cmd/modelctl/commands/set_test.go
@@ -129,6 +129,46 @@ func TestParseKeyValues(t *testing.T) {
 	}
 }
 
+func TestValidateEnvKeys(t *testing.T) {
+	tests := map[string]struct {
+		input       map[string]string
+		errContains string
+	}{
+		"non-env key with dots is allowed": {
+			input: map[string]string{"api.endpoint": "https://example.com"},
+		},
+		"valid env key": {
+			input: map[string]string{"env.my-var": "value"},
+		},
+		"env key with dot is rejected": {
+			input:       map[string]string{"env.a.b": "c"},
+			errContains: "dots are not allowed",
+		},
+		"env key with trailing dot is rejected": {
+			input:       map[string]string{"env.var.": "value"},
+			errContains: "dots are not allowed",
+		},
+	}
+
+	for testName, testCase := range tests {
+		t.Run(testName, func(t *testing.T) {
+			err := validateEnvKeys(testCase.input)
+			if testCase.errContains != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", testCase.errContains)
+				}
+				if !strings.Contains(err.Error(), testCase.errContains) {
+					t.Fatalf("expected error containing %q, got %q", testCase.errContains, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %q", err.Error())
+			}
+		})
+	}
+}
+
 func TestSetValueSuccessForUserConfig(t *testing.T) {
 	mockConfig := storage.NewMockConfig()
 	mockConfig.Set("api.endpoint", "https://old.example.com", storage.UserConfig)

--- a/cmd/modelctl/commands/set_test.go
+++ b/cmd/modelctl/commands/set_test.go
@@ -148,6 +148,10 @@ func TestValidateEnvKeys(t *testing.T) {
 			input:       map[string]string{"env.var.": "value"},
 			errContains: "dots are not allowed",
 		},
+		"env key with empty name is rejected": {
+			input:       map[string]string{"env.": "value"},
+			errContains: "must not be empty",
+		},
 	}
 
 	for testName, testCase := range tests {

--- a/pkg/storage/config.go
+++ b/pkg/storage/config.go
@@ -26,6 +26,10 @@ func NewConfig() Config {
 
 const configKeyPrefix = "config"
 
+// EnvKeyPrefix is the prefix used for configuration keys that are passed
+// through as environment variables to the running snap.
+const EnvKeyPrefix = "env."
+
 type configType string
 
 // config precedence, from lowest to highest


### PR DESCRIPTION
By accepting environment variables names with dots the CLI produce and export environment varibales not POSIX compliant.

Now dots and trailng dots are no more accepted.

```
$ sudo stack-utils set env.a.b=c
Error: invalid key "env.a.b": dots are not allowed in environment variable names
$ sudo stack-utils set env.ab=c
Restart stack-utils to apply the changes? [Y/n] n
```