### PR TITLE
Use a UserMessage to check server readiness

### DIFF
--- a/cmd/modelctl/common/chat.go
+++ b/cmd/modelctl/common/chat.go
@@ -163,7 +163,7 @@ func (c *chatClient) handshake() error {
 func (c *chatClient) checkServerReady() error {
 	params := openai.ChatCompletionNewParams{
 		Messages: []openai.ChatCompletionMessageParamUnion{
-			openai.SystemMessage("Are you up?"),
+			openai.UserMessage("Are you up?"),
 		},
 		Model:               c.modelName,
 		MaxCompletionTokens: openai.Int(1),


### PR DESCRIPTION
Some GGUF models  (e.g. https://huggingface.co/unsloth/Qwen3.5-9B-GGUF) may enforce a check on role when prompted. `chat` command was not filling the role when checking for readiness. This PR fix this issue