### PR TITLE
Get model capabilities from metadata

### DIFF
--- a/cmd/modelctl/commands/debug/serve-webui.go
+++ b/cmd/modelctl/commands/debug/serve-webui.go
@@ -45,7 +45,7 @@ func (cmd *serveWebUiCommand) serveWebUi(_ *cobra.Command, args []string) error 
 
 	config := webui.Config{
 		OpenAIBaseURL: cmd.baseUrl,
-		Capabilities:  webui.SupportedCapabilities(), // set all capabilities for debugging
+		Capabilities:  common.SupportedCapabilities(), // set all capabilities for debugging
 		InstanceName:  "debug",
 		EngineName:    "unset",
 	}

--- a/cmd/modelctl/commands/serve-webui.go
+++ b/cmd/modelctl/commands/serve-webui.go
@@ -61,16 +61,20 @@ func (cmd *serveWebUiCommand) serveWebUi(_ *cobra.Command, args []string) error 
 
 	activeModelId, err := cmd.Cache.GetActiveModel()
 	if err != nil {
-		return fmt.Errorf("getting active model: %v", err)
+		return fmt.Errorf("getting active model: %w", err)
 	}
 
-	var capabilities []string
+	// Always send an array (possibly empty) so the /config response has a
+	// stable shape and never serializes capabilities as JSON null.
+	capabilities := []string{}
 	if activeModelId != "" {
 		modelManifest, err := models.LoadManifest(cmd.ModelsDir, activeModelId)
 		if err != nil {
-			return fmt.Errorf("loading model manifest: %v", err)
+			return fmt.Errorf("loading model manifest: %w", err)
 		}
-		capabilities = modelManifest.Capabilities
+		if modelManifest.Capabilities != nil {
+			capabilities = modelManifest.Capabilities
+		}
 	}
 
 	config := webui.Config{

--- a/cmd/modelctl/commands/serve-webui.go
+++ b/cmd/modelctl/commands/serve-webui.go
@@ -2,10 +2,10 @@ package commands
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/canonical/go-snapctl/env"
 	"github.com/canonical/inference-snaps-cli/v2/cmd/modelctl/common"
+	"github.com/canonical/inference-snaps-cli/v2/pkg/models"
 	"github.com/canonical/inference-snaps-cli/v2/pkg/webui"
 	"github.com/spf13/cobra"
 )
@@ -14,9 +14,8 @@ type serveWebUiCommand struct {
 	*common.Context
 
 	// flags
-	port         int
-	host         string // bind address
-	capabilities string
+	port int
+	host string // bind address
 }
 
 func ServeWebUi(ctx *common.Context) *cobra.Command {
@@ -35,8 +34,6 @@ func ServeWebUi(ctx *common.Context) *cobra.Command {
 	// flags
 	cobraCmd.Flags().IntVar(&cmd.port, "port", 8081, "HTTP bind port")
 	cobraCmd.Flags().StringVar(&cmd.host, "host", "localhost", "HTTP bind address")
-	cobraCmd.Flags().StringVar(&cmd.capabilities, "capabilities", "text",
-		fmt.Sprintf("Comma-separated list of capabilities (%s)", strings.Join(webui.SupportedCapabilities(), ", ")))
 
 	return cobraCmd
 }
@@ -62,9 +59,18 @@ func (cmd *serveWebUiCommand) serveWebUi(_ *cobra.Command, args []string) error 
 		return common.ErrNoActiveEngine
 	}
 
+	activeModelId, err := cmd.Cache.GetActiveModel()
+	if err != nil {
+		return fmt.Errorf("getting active model: %v", err)
+	}
+
 	var capabilities []string
-	for cap := range strings.SplitSeq(cmd.capabilities, ",") {
-		capabilities = append(capabilities, strings.TrimSpace(cap))
+	if activeModelId != "" {
+		modelManifest, err := models.LoadManifest(cmd.ModelsDir, activeModelId)
+		if err != nil {
+			return fmt.Errorf("loading model manifest: %v", err)
+		}
+		capabilities = modelManifest.Capabilities
 	}
 
 	config := webui.Config{

--- a/cmd/modelctl/common/model.go
+++ b/cmd/modelctl/common/model.go
@@ -17,10 +17,6 @@ const (
 	capabilityThinking string = "thinking"
 )
 
-func SupportedCapabilities() []string {
-	return []string{capabilityText, capabilityVision, capabilityTools, capabilityThinking}
-}
-
 type ModelDetails struct {
 	ID   string `json:"id" yaml:"id"`
 	Name string `json:"name" yaml:"name"`
@@ -33,6 +29,10 @@ type ModelDetails struct {
 	DiskSize string `json:"disk-size" yaml:"disk-size"`
 
 	Components []string `json:"components" yaml:"components"`
+}
+
+func SupportedCapabilities() []string {
+	return []string{capabilityText, capabilityVision, capabilityTools, capabilityThinking}
 }
 
 func NewModelDetails(manifest *models.Manifest) (ModelDetails, error) {

--- a/cmd/modelctl/common/model.go
+++ b/cmd/modelctl/common/model.go
@@ -10,6 +10,17 @@ import (
 	"github.com/canonical/inference-snaps-cli/v2/pkg/utils"
 )
 
+const (
+	capabilityText     string = "text"
+	capabilityVision   string = "vision"
+	capabilityTools    string = "tools"
+	capabilityThinking string = "thinking"
+)
+
+func SupportedCapabilities() []string {
+	return []string{capabilityText, capabilityVision, capabilityTools, capabilityThinking}
+}
+
 type ModelDetails struct {
 	ID   string `json:"id" yaml:"id"`
 	Name string `json:"name" yaml:"name"`

--- a/pkg/webui/config.go
+++ b/pkg/webui/config.go
@@ -12,17 +12,6 @@ type Config struct {
 	EngineName    string   `json:"engineName"`
 }
 
-const (
-	capabilityText     string = "text"
-	capabilityVision   string = "vision"
-	capabilityTools    string = "tools"
-	capabilityThinking string = "thinking"
-)
-
-func SupportedCapabilities() []string {
-	return []string{capabilityText, capabilityVision, capabilityTools, capabilityThinking}
-}
-
 func (c Config) Validate() error {
 
 	// Validate OpenAI base URL

--- a/pkg/webui/config.go
+++ b/pkg/webui/config.go
@@ -19,8 +19,5 @@ func (c Config) Validate() error {
 		return fmt.Errorf("invalid OpenAI base URL: %w", err)
 	}
 
-	// Capabilities are forwarded as-is; the frontend ignores any it does not
-	// recognize, so unknown capabilities are not rejected here.
-
 	return nil
 }

--- a/pkg/webui/config.go
+++ b/pkg/webui/config.go
@@ -3,7 +3,6 @@ package webui
 import (
 	"fmt"
 	"net/url"
-	"slices"
 )
 
 type Config struct {
@@ -14,13 +13,14 @@ type Config struct {
 }
 
 const (
-	capabilityText         string = "text"
-	capabilityTextMarkdown string = "text:markdown"
-	capabilityVision       string = "vision"
+	capabilityText     string = "text"
+	capabilityVision   string = "vision"
+	capabilityTools    string = "tools"
+	capabilityThinking string = "thinking"
 )
 
 func SupportedCapabilities() []string {
-	return []string{capabilityText, capabilityTextMarkdown, capabilityVision}
+	return []string{capabilityText, capabilityVision, capabilityTools, capabilityThinking}
 }
 
 func (c Config) Validate() error {
@@ -30,12 +30,8 @@ func (c Config) Validate() error {
 		return fmt.Errorf("invalid OpenAI base URL: %w", err)
 	}
 
-	// Validate capabilities
-	for _, cap := range c.Capabilities {
-		if !slices.Contains(SupportedCapabilities(), cap) {
-			return fmt.Errorf("unsupported capability: %q", cap)
-		}
-	}
+	// Capabilities are forwarded as-is; the frontend ignores any it does not
+	// recognize, so unknown capabilities are not rejected here.
 
 	return nil
 }

--- a/pkg/webui/config_test.go
+++ b/pkg/webui/config_test.go
@@ -4,23 +4,6 @@ import (
 	"testing"
 )
 
-func TestSupportedCapabilities(t *testing.T) {
-	caps := SupportedCapabilities()
-	if len(caps) == 0 {
-		t.Fatal("expected non-empty capabilities list")
-	}
-	found := map[string]bool{}
-	for _, c := range caps {
-		found[c] = true
-	}
-	if !found["text"] {
-		t.Error("expected 'text' in supported capabilities")
-	}
-	if !found["vision"] {
-		t.Error("expected 'vision' in supported capabilities")
-	}
-}
-
 func TestConfigValidate(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -70,20 +53,20 @@ func TestConfigValidate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "unsupported capability",
+			name: "unknown capability is accepted (forwarded to frontend)",
 			config: Config{
 				OpenAIBaseURL: "http://localhost:11434/v1",
 				Capabilities:  []string{"audio"},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
-			name: "one valid one invalid capability",
+			name: "known and unknown capability are accepted",
 			config: Config{
 				OpenAIBaseURL: "http://localhost:11434/v1",
 				Capabilities:  []string{"text", "unknown"},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "nil capabilities",

--- a/pkg/webui/config_test.go
+++ b/pkg/webui/config_test.go
@@ -56,15 +56,7 @@ func TestConfigValidate(t *testing.T) {
 			name: "unknown capability is accepted (forwarded to frontend)",
 			config: Config{
 				OpenAIBaseURL: "http://localhost:11434/v1",
-				Capabilities:  []string{"audio"},
-			},
-			wantErr: false,
-		},
-		{
-			name: "known and unknown capability are accepted",
-			config: Config{
-				OpenAIBaseURL: "http://localhost:11434/v1",
-				Capabilities:  []string{"text", "unknown"},
+				Capabilities:  []string{"unknown"},
 			},
 			wantErr: false,
 		},

--- a/snap/local/server-webui.sh
+++ b/snap/local/server-webui.sh
@@ -4,7 +4,4 @@ set -euo pipefail
 port="$(modelctl get webui.http.port)"
 host="$(modelctl get webui.http.host)"
 
-# The capabilities depend on the model and engine size
-capabilities="text, text:markdown, vision"
-
-exec modelctl serve-webui "$SNAP/webui" --port "$port" --host "$host" --capabilities "$capabilities"
+exec modelctl serve-webui "$SNAP/webui" --port "$port" --host "$host"


### PR DESCRIPTION
Model capabilities are now retrieved from metadata inside `model.yaml` and passed to webui, dropping the need for hardcoded values.

Supported capabilities are validated at build time for each model against a known list ([PR](https://github.com/canonical/inference-snaps-cli/pull/394)).

Frontend will ignore and not show any unsupported capability ([PR](https://github.com/canonical/inference-snaps-webui/pull/129))
