### PR TITLE
fix: Use lscpu to detect lack of confinement

### DIFF
--- a/pkg/snap/snap.go
+++ b/pkg/snap/snap.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/canonical/go-snapctl"
@@ -47,16 +48,16 @@ func (*snap) HardwareObservable() (bool, error) {
 		return true, nil
 	}
 
-	_, err = os.ReadDir("/sys/bus/pci/devices")
-	if err == nil {
+	// Hardware access is available also if the snap is installed without confinement.
+	// Verify by running lscpu from the system path (not staged in the snap)
+	if err := exec.Command("/usr/bin/lscpu", "-V").Run(); err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			return false, nil
+		}
+		return false, fmt.Errorf("checking lscpu availability: %w", err)
+	} else {
 		return true, nil
 	}
-
-	if errors.Is(err, os.ErrPermission) || os.IsPermission(err) {
-		return false, nil
-	}
-
-	return false, fmt.Errorf("reading /sys/bus/pci/devices: %w", err)
 }
 
 // InstallComponent installs a single snap component.
@@ -81,4 +82,3 @@ func (*snap) ServiceStatuses() (map[string]string, error) {
 	}
 	return statuses, nil
 }
-


### PR DESCRIPTION
Auto engine selection is expected to use the set fallback when there is no access to detect the hardware. The fallback logic is broken since the auto-connected opengl interface now grants access to read `/sys/bus/pci/devices`. This path was being checked to assume unconfined installation, which now produces a false positive (hardware-observe not connected, confined installation) and result in errors while reading USB devices.

```console
$ sudo stack-utils use-engine --auto --fallback=cpu
Error: scoring engines: getting machine info: getting devices: reading sysfs usb devices: reading sys/bus/usb/devices: open sys/bus/usb/devices: permission denied
```

This PR changes the logic and relies on lscpu command instead, similar to [how it was being done](https://github.com/canonical/gemma3-snap/blob/c011e0cdfd25ef08c38960e0d1a827a7af167fc8/snap/hooks/install#L24) before implementing the --fallback flag. This now improved to run lscpu with the absolute system path so that staging `util-linux` which adds lscpu at `$SNAP/usr/bin/lscpu` won't get around it.

```console
$ sudo stack-utils use-engine --auto --fallback=cpu
Hardware information is unavailable; falling back to engine "cpu".
```