### PR TITLE
Use shared renovate config from dev repo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,27 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ],
-  "git-submodules": {
-    "enabled": true
-  },
-  "semanticCommits": "disabled",
-  "postUpdateOptions": [
-    "gomodTidy"
-  ],
-  "packageRules": [
-    {
-      "description": "Automerge inference-snaps-dev update PRs",
-      "matchManagers": [
-        "git-submodules"
-      ],
-      "matchDepNames": [
-        "dev"
-      ],
-      "commitBody": "[skip ci]",
-      "automerge": true,
-      "automergeType": "pr",
-      "ignoreTests": false
-    }
-  ],
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "github>canonical/inference-snaps-dev//renovate/default.jsonc#v2"
   ]
 }


### PR DESCRIPTION
This uses the shared renovate config from the inference-snap-dev repo, like other inference snap does. It is currently untested.